### PR TITLE
Copy iidy binary to proper filesystem bin path instead of root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,6 @@ FROM alpine:3.6
 
 RUN apk --no-cache add libstdc++
 
-COPY --from=0 /tmp/iidy/dist/iidy /iidy
+COPY --from=0 /tmp/iidy/dist/iidy /usr/local/bin/iidy
 
-ENTRYPOINT ["/iidy"]
+ENTRYPOINT ["/usr/local/bin/iidy"]


### PR DESCRIPTION
This allows for more flexible usage of the Docker image: shelling into the image and being able to use iidy without specifying a full path, etc.