### PR TITLE
add `filter:` argument to !$map (!$concatMap, !$mergeMap, etc.)

### DIFF
--- a/src/yaml.ts
+++ b/src/yaml.ts
@@ -141,7 +141,7 @@ addCustomTag('$expand', $expand); // mapping
 ////////////////////////////////////////////////////////////////////////////////
 // looping and data restructuring custom tags
 
-export type $MapParams = {template: any, items: any[], var?: string};
+export type $MapParams = {template: any, items: any[], var?: string, filter?: any};
 export class $map extends Tag<$MapParams> {}
 addCustomTag('$map', $map); // mapping
 


### PR DESCRIPTION
This optional argument allows items to be filter out while doing a
!$map.

```
example: !$map
  items:
    - name: a
      public: true
    - name: b
      public: true
    - name: c
      public: false
  template: !$ item.name
  filter:  !$ item.public

```

yields:
```
example:
  - a
  - b
```