### PR TITLE
[WIP] create a publish-cfn-template command

### DIFF
--- a/src/publishCfnTemplate.ts
+++ b/src/publishCfnTemplate.ts
@@ -1,0 +1,5 @@
+import {Arguments} from 'yargs';
+
+export async function publishCfnTemplate(argv: Arguments): Promise<string> {
+  return "Hello, World!";
+}


### PR DESCRIPTION
upload a cfn-template to an s3 bucket.

First upload of file and following naming conventions:
```
iidy publish-cfn-template --s3-bucket=s3://your-company-production/your-app
```

For succeeding uploads given that template in stack args is s3://your-company-production/your-app:
```
iidy publish-cfn-template
```

When not following the nameing conventions:
```
iidy publish-cfn-template --s3-bucket=s3://your-company-production/your-app --cfn-template=./my-custom-template.yaml
iidy publish-cfn-template --cfn-template=./my-custom-template.yaml
```