### PR TITLE
Create approve templates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apk update && apk add --no-cache binutils \
 
 FROM alpine:3.6
 
-RUN apk --no-cache add libstdc++
+RUN apk --no-cache add libstdc++ git
 
 COPY --from=0 /tmp/iidy/dist/iidy /usr/local/bin/iidy
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,11 @@
       "integrity": "sha1-LlsjXIxVZSxP7ChFBtKjb+Zf6H4=",
       "dev": true
     },
+    "@types/diff": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-3.2.2.tgz",
+      "integrity": "sha512-q3zfJvaTroV5BjAAR+peTHEGAAhGrPX0z2EzCzpt2mwFA+qzUn2nigJLqSekXRtdULKmT8am7zjvTMZSapIgHw=="
+    },
     "@types/form-data": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.0.tgz",
@@ -819,8 +824,7 @@
     "diff": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
-      "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
-      "dev": true
+      "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA=="
     },
     "ecc-jsbn": {
       "version": "0.1.1",
@@ -2741,6 +2745,11 @@
           "dev": true
         }
       }
+    },
+    "ts-md5": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/ts-md5/-/ts-md5-1.2.2.tgz",
+      "integrity": "sha512-rTjX9/xTOvAcKC7TIsahiSdeyXgMtKa4wd6iClduCWeVoj41Q/HX5oYLkJzHQktW/DHbBjUatoFj0Q481N/Idw=="
     },
     "tslib": {
       "version": "1.8.0",

--- a/package.json
+++ b/package.json
@@ -21,10 +21,12 @@
     "npm": ">=4.0"
   },
   "dependencies": {
+    "@types/diff": "^3.2.2",
     "aws-sdk": "^2.167.0",
     "bluebird": "^3.5.1",
     "cli-color": "^1.2.0",
     "dateformat": "^2.0.0",
+    "diff": "^3.4.0",
     "handlebars": "^4.0.10",
     "inquirer": "^3.3.0",
     "jmespath": "0.15.0",
@@ -36,6 +38,7 @@
     "request": "^2.83.0",
     "request-promise-native": "^1.0.5",
     "tmp": "0.0.31",
+    "ts-md5": "^1.2.2",
     "tv4": "^1.3.0",
     "winston": "^2.4.0",
     "wrap-ansi": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -21,12 +21,10 @@
     "npm": ">=4.0"
   },
   "dependencies": {
-    "@types/diff": "^3.2.2",
     "aws-sdk": "^2.167.0",
     "bluebird": "^3.5.1",
     "cli-color": "^1.2.0",
     "dateformat": "^2.0.0",
-    "diff": "^3.4.0",
     "handlebars": "^4.0.10",
     "inquirer": "^3.3.0",
     "jmespath": "0.15.0",

--- a/src/approval/cli.ts
+++ b/src/approval/cli.ts
@@ -1,0 +1,46 @@
+import * as yargs from 'yargs';
+
+import { description, Handler, wrapCommandHandler } from '../cli';
+
+export interface ApprovalCommands {
+    request: Handler;
+    review: Handler;
+}
+
+const lazyLoad = (fnname: keyof ApprovalCommands): Handler =>
+    (args) => require('../approval')[fnname](args);
+
+const lazy: ApprovalCommands = {
+    request: lazyLoad('request'),
+    review: lazyLoad('review')
+}
+
+export function buildApprovalCommands(args: yargs.Argv, commands = lazy): yargs.Argv {
+    return args
+        .strict()
+        .demandCommand(1, 0)
+        .command(
+        'request <argsfile>',
+        description('request template approval'),
+        (args) => args
+            .demandCommand(0, 0)
+            .usage('Usage: iidy template-approval request stack-args.yaml')
+            .strict(),
+        wrapCommandHandler(commands.request)
+        )
+
+        .command(
+        'review <url>',
+        description('review pending template approval request'),
+        (args) => args
+            .demandCommand(0, 0)
+            .option('context', {
+              type: 'number', default: 100,
+              description: description('how many lines of diff context to show')
+            })
+            .usage('Usage: iidy template-approval review s3://bucket/path.pending')
+            .strict(),
+        wrapCommandHandler(commands.review)
+        );
+
+}

--- a/src/approval/index.ts
+++ b/src/approval/index.ts
@@ -1,0 +1,173 @@
+import { S3 } from 'aws-sdk';
+import { Md5 } from 'ts-md5/dist/md5';
+import * as fs from 'fs';
+import * as cli from 'cli-color';
+import * as path from 'path';
+import * as url from 'url';
+import * as jsdiff from 'diff';
+import * as inquirer from 'inquirer';
+
+import { Arguments } from 'yargs';
+import { loadStackArgs } from '../cfn/index';
+import configureAWS from '../configureAWS';
+import { logger } from '../logger';
+
+export async function requestApproveTemplate(argv: Arguments): Promise<number> {
+    const stackArgs = await loadStackArgs(argv);
+
+    if (typeof stackArgs.ApprovedTemplateLocation === 'string' && stackArgs.ApprovedTemplateLocation.length > 0) {
+        const s3 = new S3();
+
+        await configureAWS(stackArgs.Profile, stackArgs.Region);
+
+        const templatePath = path.resolve(path.dirname(argv.argsfile), stackArgs.Template);
+        const cfnTemplate = await fs.readFileSync(templatePath);
+
+        const s3Url = url.parse(stackArgs.ApprovedTemplateLocation);
+        const s3Path = s3Url.path ? s3Url.path : '';
+        const s3Bucket = s3Url.hostname ? s3Url.hostname : '';
+
+        const fileName = new Md5().appendStr(cfnTemplate.toString()).end().toString();
+        const fullFileName = `${fileName}${path.extname(stackArgs.Template)}.pending`;
+
+        const hashedKey = path.join(s3Path.substring(1), fullFileName);
+
+        try {
+            await s3.headObject({
+                Bucket: s3Bucket,
+                Key: hashedKey
+            }).promise();
+
+            logSuccess(`👍 Your template has already been approved`);
+        } catch (e) {
+            if (e.code === 'NotFound') {
+                await s3.putObject({
+                    Body: cfnTemplate,
+                    Bucket: s3Bucket,
+                    Key: hashedKey
+                }).promise();
+
+                logSuccess(`Successfully uploaded the cloudformation template to ${stackArgs.ApprovedTemplateLocation}`);
+                logSuccess(`Approve template with:\n  iidy approve-template s3://${s3Bucket}/${hashedKey}`);
+            } else {
+                throw new Error(e);
+            }
+        }
+
+        return 0;
+    } else {
+        logError(`\`ApprovedTemplateLocation\` must be provided in ${argv.argsfile}`);
+        return 1;
+    }
+
+}
+
+export async function approveTemplate(argv: Arguments): Promise<number> {
+    await configureAWS(argv.profile, 'us-east-1');
+    const s3 = new S3();
+
+    const s3Url = url.parse(argv.filename);
+    const s3Path = s3Url.path ? s3Url.path.replace(/^\//, '') : '';
+    const s3Bucket = s3Url.hostname ? s3Url.hostname : '';
+
+    const bucketDir = path.parse(s3Path).dir;
+
+    try {
+        await s3.headObject({
+            Bucket: s3Bucket,
+            Key: s3Path.replace(/\.pending$/, '')
+        }).promise();
+
+        logSuccess(`👍 The template has already been approved`);
+    } catch (e) {
+        if (e.code === 'NotFound') {
+
+            const pendingTemplate = await s3.getObject({
+                Bucket: s3Bucket,
+                Key: s3Path
+            }).promise().then((template) => template.Body);
+
+            const previouslyApprovedTemplate = await s3.getObject({
+                Bucket: s3Bucket,
+                Key: `${bucketDir}/latest`
+            }).promise()
+                .then((template) => template.Body)
+                .catch((e) => {
+                    if (e.code !== 'NoSuchKey') {
+                        return Promise.reject(e);
+                    }
+                    return Buffer.from('');
+                });
+
+            const diff = jsdiff.diffLines(
+                previouslyApprovedTemplate!.toString(),
+                pendingTemplate!.toString(),
+            );
+            let colorizedString = '';
+
+            diff.forEach(function(part) {
+                if (part.added) {
+                    colorizedString = colorizedString + cli.green(part.value);
+                } else if (part.removed) {
+                    colorizedString = colorizedString + cli.red(part.value);
+                }
+            });
+            console.log(colorizedString);
+
+            const resp = await inquirer.prompt(
+                {
+                    name: 'confirmed',
+                    type: 'confirm', default: false,
+                    message: `Do these changes look good for you?`
+                });
+
+            if (resp.confirmed) {
+                // create a new pending file
+                await s3.putObject({
+                    Body: pendingTemplate,
+                    Bucket: s3Bucket,
+                    Key: s3Path.replace(/\.pending$/, '')
+                }).promise();
+                logDebug('Created a new cfn-template');
+
+                // copy to latest
+                await s3.putObject({
+                    Body: pendingTemplate,
+                    Bucket: s3Bucket,
+                    Key: `${bucketDir}/latest`
+                }).promise();
+                logDebug('Updated latest');
+
+                // delete the old pending file
+                await s3.deleteObject({
+                    Bucket: s3Bucket,
+                    Key: s3Path
+                }).promise();
+                logDebug('Deleted pending file.');
+
+                console.log();
+                logSuccess(`Template has been successfully approved!`);
+                return 0;
+            } else {
+                return 0;
+            }
+
+        } else {
+            throw new Error(e);
+        }
+    }
+
+    return 0;
+}
+
+function logSuccess(text: string) {
+    logger.info(cli.green(text));
+}
+
+function logDebug(text: string) {
+    logger.debug(text);
+}
+
+function logError(text: string) {
+    logger.error(cli.red(text));
+}

--- a/src/cfn/index.ts
+++ b/src/cfn/index.ts
@@ -41,6 +41,7 @@ export type CfnOperation = 'CREATE_STACK' | 'UPDATE_STACK' | 'CREATE_CHANGESET' 
 export type StackArgs = {
   StackName: string
   Template: string
+  ApprovedTemplateLocation?: string
   Region?: AWSRegion
   Profile?: string
   Capabilities?: aws.CloudFormation.Capabilities
@@ -1515,6 +1516,7 @@ export async function convertStackToIIDY(argv: Arguments): Promise<number> {
   const stackArgs: StackArgs = {
     Template: './cfn-template.yaml',
     StackName: StackNameArg,
+    ApprovedTemplateLocation: undefined,
     Parameters,
     Tags,
     StackPolicy: './stack-policy.json',

--- a/src/cfn/index.ts
+++ b/src/cfn/index.ts
@@ -6,6 +6,8 @@ import * as url from 'url';
 
 import * as _ from 'lodash';
 import * as aws from 'aws-sdk'
+import { Md5 } from 'ts-md5/dist/md5';
+import * as request from 'request-promise-native';
 
 import * as dateformat from 'dateformat';
 
@@ -18,7 +20,6 @@ import * as wrapAnsi from 'wrap-ansi';
 import * as ora from 'ora';
 import * as inquirer from 'inquirer';
 import * as nameGenerator from 'project-name-generator';
-import * as tmp from 'tmp';
 
 let getStrippedLength: (s: string) => number;
 // TODO declare module for this:
@@ -32,6 +33,7 @@ import configureAWS from '../configureAWS';
 import {AWSRegion} from '../aws-regions';
 import timeout from '../timeout';
 import def from '../default';
+import {diff} from '../diff';
 
 import {readFromImportLocation, transform} from '../preprocess';
 import {getKMSAliasForParameter} from '../params';
@@ -584,7 +586,7 @@ async function loadCFNStackPolicy(policy: string | object | undefined, baseLocat
 }
 
 const TEMPLATE_MAX_BYTES = 51199
-async function loadCFNTemplate(location0: string, baseLocation: string):
+export async function loadCFNTemplate(location0: string, baseLocation: string, omitMetadata = false):
   Promise<{TemplateBody?: string, TemplateURL?: string}> {
   if (_.isUndefined(location0)) {
     return {};
@@ -619,7 +621,7 @@ async function loadCFNTemplate(location0: string, baseLocation: string):
       );
     }
     const body = shouldRender
-      ? yaml.dump(await transform(importData.doc, importData.resolvedLocation))
+      ? yaml.dump(await transform(importData.doc, importData.resolvedLocation, omitMetadata))
       : importData.data;
     if (body.length >= TEMPLATE_MAX_BYTES) {
       throw new Error('Your cloudformation template is larger than the max allowed size. '
@@ -865,14 +867,33 @@ export async function _loadStackArgs(argsfile: string, region?: AWSRegion, profi
 
 async function stackArgsToCreateStackInput(stackArgs: StackArgs, argsFilePath: string, stackName?: string)
   : Promise<aws.CloudFormation.CreateStackInput> {
+  let templateLocation;
 
+  if(stackArgs.ApprovedTemplateLocation) {
+    const approvedLocation = await approvedTemplateVersionLocation(
+      stackArgs.ApprovedTemplateLocation,
+      stackArgs.Template,
+      argsFilePath
+    );
+    templateLocation = `https://s3.amazonaws.com/${approvedLocation.Bucket}/${approvedLocation.Key}`;
+  } else {
+    templateLocation = stackArgs.Template;
+  }
   // Template is optional for updates and update changesets
-  const {TemplateBody, TemplateURL} = await loadCFNTemplate(stackArgs.Template, argsFilePath);
+  const {TemplateBody, TemplateURL} = await loadCFNTemplate(templateLocation, argsFilePath);
   const {StackPolicyBody, StackPolicyURL} = await loadCFNStackPolicy(stackArgs.StackPolicy, argsFilePath);
 
   // TODO: DisableRollback
   // specify either DisableRollback or OnFailure, but not both
   const OnFailure = def('ROLLBACK', stackArgs.OnFailure)
+
+  if(stackArgs.ApprovedTemplateLocation) {
+    logger.debug(`ApprovedTemplateLocation: ${stackArgs.ApprovedTemplateLocation}`);
+    logger.debug(`Original Template: ${stackArgs.Template}`);
+    logger.debug(`TemplateURL with ApprovedTemplateLocation: ${TemplateURL}`);
+  } else {
+    logger.debug(`TemplateURL: ${TemplateURL}`);
+  }
 
   return {
     StackName: def(stackArgs.StackName, stackName),
@@ -996,6 +1017,7 @@ abstract class AbstractCloudFormationStackCommand {
 
     const iamIdent = await iamIdentPromise;
     printSectionEntry('Current IAM Principal:', cli.blackBright(iamIdent.Arn));
+
     console.log();
   }
 
@@ -1052,6 +1074,19 @@ class CreateStack extends AbstractCloudFormationStackCommand {
   }
 }
 
+async function isHttpTemplateAccessible(location?: string) {
+    if(location) {
+        try {
+          await request.get(location);
+          return true;
+        } catch (e) {
+            return false;
+        }
+    } else {
+        return false;
+    }
+}
+
 class UpdateStack extends AbstractCloudFormationStackCommand {
   _cfnOperation: CfnOperation = 'UPDATE_STACK'
   _expectedFinalStackStatus = ['UPDATE_COMPLETE']
@@ -1059,6 +1094,12 @@ class UpdateStack extends AbstractCloudFormationStackCommand {
   async _run() {
     try {
       let updateStackInput = await stackArgsToUpdateStackInput(this.stackArgs, this.argsfile, this.stackName);
+      if(this.stackArgs.ApprovedTemplateLocation && ! await isHttpTemplateAccessible(updateStackInput.TemplateURL)) {
+        logger.error('Template version is has not been approved or the current IAM principal does not have permission to access it. Run:');
+        logger.error(`  iidy template-approval request ${this.argsfile}`);
+        logger.error('to being the approval process.');
+        return 1;
+      }
       if (this.argv.stackPolicyDuringUpdate) {
         const {
           StackPolicyBody: StackPolicyDuringUpdateBody,
@@ -1271,24 +1312,7 @@ export async function diffStackTemplates(StackName: string, stackArgs: StackArgs
     }
 
     console.log();
-    const tmpdir = tmp.dirSync();
-    const oldName = pathmod.join(tmpdir.name, 'old');
-    const newName = pathmod.join(tmpdir.name, 'new');
-    try {
-      fs.writeFileSync(oldName, yaml.dump(oldTemplate));
-      fs.writeFileSync(newName, yaml.dump(newTemplate));
-      const res = child_process.spawnSync(
-        `git diff --no-index --color -- ${oldName} ${newName}`, {
-          shell: '/bin/bash',
-          stdio: [0, 1, 2]
-        });
-    } catch (e) {
-      throw e;
-    } finally {
-      fs.unlinkSync(oldName);
-      fs.unlinkSync(newName);
-      fs.rmdirSync(tmpdir.name)
-    }
+    diff(yaml.dump(oldTemplate), yaml.dump(newTemplate))
   }
 }
 
@@ -1618,5 +1642,31 @@ export async function deleteStackMain(argv: Arguments): Promise<number> {
     return showFinalComandSummary(StackStatus === 'DELETE_COMPLETE');
   } else {
     return 1
+  }
+}
+
+export async function approvedTemplateVersionLocation(
+  approvedTemplateLocation: string,
+  templatePath: string,
+  baseLocation: string): Promise<{Bucket: string, Key: string}> {
+  // const templatePath = path.resolve(path.dirname(location), templatePath);
+  // const cfnTemplate = await fs.readFileSync(path.resolve(path.dirname(location), templatePath));
+  const omitMetadata = true;
+  const cfnTemplate = await loadCFNTemplate(templatePath, baseLocation, omitMetadata);
+
+  if(cfnTemplate && cfnTemplate.TemplateBody) {
+    const s3Url = url.parse(approvedTemplateLocation);
+    const s3Path = s3Url.path ? s3Url.path : "";
+    const s3Bucket = s3Url.hostname ? s3Url.hostname : "";
+
+    const fileName = new Md5().appendStr(cfnTemplate.TemplateBody.toString()).end().toString()
+    const fullFileName = `${fileName}${pathmod.extname(templatePath)}`
+
+    return {
+      Bucket: s3Bucket,
+      Key: pathmod.join(s3Path.substring(1), fullFileName)
+    };
+  } else {
+    throw new Error('Unable to determine versioned template location');
   }
 }

--- a/src/diff/index.ts
+++ b/src/diff/index.ts
@@ -1,0 +1,36 @@
+import * as pathmod from 'path';
+import * as tmp from 'tmp';
+import * as fs from 'fs';
+import * as child_process from 'child_process';
+
+import {logger} from '../logger';
+
+export function diff(a: string, b: string, context = 3): void {
+  const tmpdir = tmp.dirSync();
+  const aPath = pathmod.join(tmpdir.name, 'a');
+  const bPath = pathmod.join(tmpdir.name, 'b');
+  try {
+    fs.writeFileSync(aPath, a);
+    fs.writeFileSync(bPath, b);
+    // git-diff is used as it is the easist way to get a cross-platform colour diff
+    const cmd = `git --no-pager diff --no-index -U${context} --color -- ${aPath} ${bPath}`;
+    const res = child_process.spawnSync(
+      cmd, {
+        shell: '/bin/sh',
+        stdio: [0, 1, 2]
+      }
+    );
+
+    if(res.status === 0) {
+      logger.info('Templates are the same');
+    } else if(res.status !== 1) {
+      throw new Error(`Error producing diff "${cmd}"`);
+    }
+  } catch (e) {
+    throw e;
+  } finally {
+    fs.unlinkSync(aPath);
+    fs.unlinkSync(bPath);
+    fs.rmdirSync(tmpdir.name);
+  }
+}

--- a/src/initStackArgs.ts
+++ b/src/initStackArgs.ts
@@ -7,11 +7,16 @@ export async function initStackArgs(argv: Arguments): Promise<number> {
     Type: "AWS::CloudFormation::WaitConditionHandle"
     Properties: {}`;
 
-  const stackArgs = `# REQUIRED SETTINGS:
+  const stackArgs = `# INITIALIZED STACK ARGS
+# $imports:
+#   environment: env:ENVIRONMENT
+
+# REQUIRED SETTINGS:
 StackName: <string>
 Template: ./cfn-template.yaml
 # optionally you can use the yaml pre-processor by prepending 'render:' to the filename
 # Template: render:<local file path or s3 path>
+# ApprovedTemplateLocation: s3://your-bucket/
 
 # OPTIONAL SETTINGS:
 # Region: <aws region name>

--- a/src/preprocess/index.ts
+++ b/src/preprocess/index.ts
@@ -1130,19 +1130,25 @@ export function visitString(node: string, path: string, env: Env): string {
 export function transformPostImports(
   root: ExtendedCfnDoc,
   rootDocLocation: ImportLocation,
-  accumulatedImports: ImportRecord[]
+  accumulatedImports: ImportRecord[],
+  omitMetadata = false
 )
-  : CfnDoc {
-  // TODO add the rootDoc to the Imports record
-  const globalAccum: CfnDoc = {
-    Metadata: {
-      iidy: {
-        Host: os.hostname(),
-        Imports: accumulatedImports,
-        User: os.userInfo().username
+: CfnDoc {
+    let globalAccum: CfnDoc;
+    if(omitMetadata) {
+      globalAccum = {};
+    } else {
+      // TODO add the rootDoc to the Imports record
+      globalAccum  = {
+        Metadata: {
+          iidy: {
+            Host: os.hostname(),
+            Imports: accumulatedImports,
+            User: os.userInfo().username
+          }
+        }
       }
-    }
-  };
+    };
 
   const seedOutput: CfnDoc = {};
   const isCFNDoc = root.AWSTemplateFormatVersion || root.Resources;
@@ -1188,12 +1194,12 @@ export function transformPostImports(
 export async function transform(
   root0: ExtendedCfnDoc,
   rootDocLocation: ImportLocation,
+  omitMetadata = false,
   importLoader = readFromImportLocation // for mocking in tests
 )
   : Promise<CfnDoc> {
   const root = _.clone(root0);
   const accumulatedImports: ImportRecord[] = [];
   await loadImports(root, rootDocLocation, accumulatedImports, importLoader);
-  return transformPostImports(root, rootDocLocation, accumulatedImports);
+  return transformPostImports(root, rootDocLocation, accumulatedImports, omitMetadata);
 };
-

--- a/src/tests/support.ts
+++ b/src/tests/support.ts
@@ -6,7 +6,7 @@ import * as jsyaml from 'js-yaml';
 
 export async function transform(input0: any, inputLoader = pre.readFromImportLocation) {
   const input = _.isString(input0) ? yaml.loadString(input0, 'root') : input0;
-  return pre.transform(input, "root", inputLoader);
+  return pre.transform(input, "root", false, inputLoader);
 }
 
 export function transformNoImport(input0: any, accumulatedImports = []) {


### PR DESCRIPTION
depends on #41 

## Usage
- Change `ApprovedTemplateLocation` to the full s3 url with key of the template to be approved
- Run command: `iidy approve-template stack-args.yaml`

### Notes:
I could also change it to `iidy approve-template https://s3.amazon.com...yaml.pending` but to add `--profile` functionality is more tedious.
Ideally, it would be using `iidy approve-template hash.yaml.pending` but the command would not know which profile to use and which bucket to look at.
 
Added a flag `--approve` to approve the template. Running the `iidy approve-template ...` command should diff the changes first. I have opted not to use a `readline` to precent fat fingering answers.

## TODO:
- [x] Switch base to master once #41 has been approved and merged
  