### PR TITLE
Replace template URL when ApprovedTemplateLocation is in use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apk update && apk add --no-cache binutils \
 
 FROM alpine:3.6
 
-RUN apk --no-cache add libstdc++
+RUN apk --no-cache add libstdc++ git
 
 COPY --from=0 /tmp/iidy/dist/iidy /usr/local/bin/iidy
 

--- a/package.json
+++ b/package.json
@@ -21,12 +21,10 @@
     "npm": ">=4.0"
   },
   "dependencies": {
-    "@types/diff": "^3.2.2",
     "aws-sdk": "^2.167.0",
     "bluebird": "^3.5.1",
     "cli-color": "^1.2.0",
     "dateformat": "^2.0.0",
-    "diff": "^3.4.0",
     "handlebars": "^4.0.10",
     "inquirer": "^3.3.0",
     "jmespath": "0.15.0",

--- a/src/approval/cli.ts
+++ b/src/approval/cli.ts
@@ -1,0 +1,42 @@
+import * as yargs from 'yargs';
+
+import { description, Handler, wrapCommandHandler } from '../cli';
+
+export interface ApprovalCommands {
+    request: Handler;
+    review: Handler;
+}
+
+const lazyLoad = (fnname: keyof ApprovalCommands): Handler =>
+    (args) => require('../approval')[fnname](args);
+
+const lazy: ApprovalCommands = {
+    request: lazyLoad('request'),
+    review: lazyLoad('review')
+}
+
+export function buildApprovalCommands(args: yargs.Argv, commands = lazy): yargs.Argv {
+    return args
+        .strict()
+        .demandCommand(1, 0)
+        .command(
+        'request <argsfile>',
+        description('request template approval'),
+        (args) => args
+            .demandCommand(0, 0)
+            .usage('Usage: iidy template-approval request stack-args.yaml')
+            .strict(),
+        wrapCommandHandler(commands.request)
+        )
+
+        .command(
+        'review <url>',
+        description('review pending template approval request'),
+        (args) => args
+            .demandCommand(0, 0)
+            .usage('Usage: iidy template-approval review s3://bucket/path.pending')
+            .strict(),
+        wrapCommandHandler(commands.review)
+        );
+
+}

--- a/src/approval/cli.ts
+++ b/src/approval/cli.ts
@@ -34,6 +34,10 @@ export function buildApprovalCommands(args: yargs.Argv, commands = lazy): yargs.
         description('review pending template approval request'),
         (args) => args
             .demandCommand(0, 0)
+            .option('context', {
+              type: 'number', default: 100,
+              description: description('how many lines of diff context to show')
+            })
             .usage('Usage: iidy template-approval review s3://bucket/path.pending')
             .strict(),
         wrapCommandHandler(commands.review)

--- a/src/approval/index.ts
+++ b/src/approval/index.ts
@@ -3,13 +3,13 @@ import * as fs from 'fs';
 import * as cli from 'cli-color';
 import * as path from 'path';
 import * as url from 'url';
-import * as jsdiff from 'diff';
 import * as inquirer from 'inquirer';
 
 import { Arguments } from 'yargs';
 import { loadStackArgs, loadCFNTemplate, approvedTemplateVersionLocation } from '../cfn/index';
 import configureAWS from '../configureAWS';
 import { logger } from '../logger';
+import { diff } from '../diff';
 
 export async function request(argv: Arguments): Promise<number> {
     const stackArgs = await loadStackArgs(argv);
@@ -85,21 +85,11 @@ export async function review(argv: Arguments): Promise<number> {
                     return Buffer.from('');
                 });
 
-            const diff = jsdiff.diffLines(
-                previouslyApprovedTemplate!.toString(),
-                pendingTemplate!.toString(),
-                { context: 100000 }
+            diff(
+              previouslyApprovedTemplate!.toString(),
+              pendingTemplate!.toString(),
+              500
             );
-            let colorizedString = '';
-
-            diff.forEach(function(part) {
-                if (part.added) {
-                    colorizedString = colorizedString + cli.green(part.value);
-                } else if (part.removed) {
-                    colorizedString = colorizedString + cli.red(part.value);
-                }
-            });
-            console.log(colorizedString);
 
             const resp = await inquirer.prompt(
                 {

--- a/src/cfn/index.ts
+++ b/src/cfn/index.ts
@@ -20,7 +20,6 @@ import * as wrapAnsi from 'wrap-ansi';
 import * as ora from 'ora';
 import * as inquirer from 'inquirer';
 import * as nameGenerator from 'project-name-generator';
-import * as tmp from 'tmp';
 
 let getStrippedLength: (s: string) => number;
 // TODO declare module for this:
@@ -34,6 +33,7 @@ import configureAWS from '../configureAWS';
 import {AWSRegion} from '../aws-regions';
 import timeout from '../timeout';
 import def from '../default';
+import {diff} from '../diff';
 
 import {readFromImportLocation, transform} from '../preprocess';
 import {getKMSAliasForParameter} from '../params';
@@ -1312,24 +1312,7 @@ export async function diffStackTemplates(StackName: string, stackArgs: StackArgs
     }
 
     console.log();
-    const tmpdir = tmp.dirSync();
-    const oldName = pathmod.join(tmpdir.name, 'old');
-    const newName = pathmod.join(tmpdir.name, 'new');
-    try {
-      fs.writeFileSync(oldName, yaml.dump(oldTemplate));
-      fs.writeFileSync(newName, yaml.dump(newTemplate));
-      const res = child_process.spawnSync(
-        `git diff --no-index --color -- ${oldName} ${newName}`, {
-          shell: '/bin/bash',
-          stdio: [0, 1, 2]
-        });
-    } catch (e) {
-      throw e;
-    } finally {
-      fs.unlinkSync(oldName);
-      fs.unlinkSync(newName);
-      fs.rmdirSync(tmpdir.name)
-    }
+    diff(yaml.dump(oldTemplate), yaml.dump(newTemplate))
   }
 }
 

--- a/src/cfn/index.ts
+++ b/src/cfn/index.ts
@@ -586,7 +586,7 @@ async function loadCFNStackPolicy(policy: string | object | undefined, baseLocat
 }
 
 const TEMPLATE_MAX_BYTES = 51199
-export async function loadCFNTemplate(location0: string, baseLocation: string):
+export async function loadCFNTemplate(location0: string, baseLocation: string, omitMetadata = false):
   Promise<{TemplateBody?: string, TemplateURL?: string}> {
   if (_.isUndefined(location0)) {
     return {};
@@ -621,7 +621,7 @@ export async function loadCFNTemplate(location0: string, baseLocation: string):
       );
     }
     const body = shouldRender
-      ? yaml.dump(await transform(importData.doc, importData.resolvedLocation))
+      ? yaml.dump(await transform(importData.doc, importData.resolvedLocation, omitMetadata))
       : importData.data;
     if (body.length >= TEMPLATE_MAX_BYTES) {
       throw new Error('Your cloudformation template is larger than the max allowed size. '
@@ -1668,7 +1668,8 @@ export async function approvedTemplateVersionLocation(
   baseLocation: string): Promise<{Bucket: string, Key: string}> {
   // const templatePath = path.resolve(path.dirname(location), templatePath);
   // const cfnTemplate = await fs.readFileSync(path.resolve(path.dirname(location), templatePath));
-  const cfnTemplate = await loadCFNTemplate(templatePath, baseLocation);
+  const omitMetadata = true;
+  const cfnTemplate = await loadCFNTemplate(templatePath, baseLocation, omitMetadata);
 
   if(cfnTemplate && cfnTemplate.TemplateBody) {
     const s3Url = url.parse(approvedTemplateLocation);

--- a/src/diff/index.ts
+++ b/src/diff/index.ts
@@ -1,0 +1,36 @@
+import * as pathmod from 'path';
+import * as tmp from 'tmp';
+import * as fs from 'fs';
+import * as child_process from 'child_process';
+
+import {logger} from '../logger';
+
+export function diff(a: string, b: string, context = 3): void {
+  const tmpdir = tmp.dirSync();
+  const aPath = pathmod.join(tmpdir.name, 'a');
+  const bPath = pathmod.join(tmpdir.name, 'b');
+  try {
+    fs.writeFileSync(aPath, a);
+    fs.writeFileSync(bPath, b);
+    // git-diff is used as it is the easist way to get a cross-platform colour diff
+    const cmd = `git --no-pager diff --no-index -U${context} --color -- ${aPath} ${bPath}`;
+    const res = child_process.spawnSync(
+      cmd, {
+        shell: '/bin/sh',
+        stdio: [0, 1, 2]
+      }
+    );
+
+    if(res.status === 0) {
+      logger.info('Templates are the same');
+    } else if(res.status !== 1) {
+      throw new Error(`Error producing diff "${cmd}"`);
+    }
+  } catch (e) {
+    throw e;
+  } finally {
+    fs.unlinkSync(aPath);
+    fs.unlinkSync(bPath);
+    fs.rmdirSync(tmpdir.name);
+  }
+}

--- a/src/preprocess/index.ts
+++ b/src/preprocess/index.ts
@@ -1130,19 +1130,25 @@ export function visitString(node: string, path: string, env: Env): string {
 export function transformPostImports(
   root: ExtendedCfnDoc,
   rootDocLocation: ImportLocation,
-  accumulatedImports: ImportRecord[]
+  accumulatedImports: ImportRecord[],
+  omitMetadata = false
 )
-  : CfnDoc {
-  // TODO add the rootDoc to the Imports record
-  const globalAccum: CfnDoc = {
-    Metadata: {
-      iidy: {
-        Host: os.hostname(),
-        Imports: accumulatedImports,
-        User: os.userInfo().username
+: CfnDoc {
+    let globalAccum: CfnDoc;
+    if(omitMetadata) {
+      globalAccum = {};
+    } else {
+      // TODO add the rootDoc to the Imports record
+      globalAccum  = {
+        Metadata: {
+          iidy: {
+            Host: os.hostname(),
+            Imports: accumulatedImports,
+            User: os.userInfo().username
+          }
+        }
       }
-    }
-  };
+    };
 
   const seedOutput: CfnDoc = {};
   const isCFNDoc = root.AWSTemplateFormatVersion || root.Resources;
@@ -1188,12 +1194,12 @@ export function transformPostImports(
 export async function transform(
   root0: ExtendedCfnDoc,
   rootDocLocation: ImportLocation,
+  omitMetadata = false,
   importLoader = readFromImportLocation // for mocking in tests
 )
   : Promise<CfnDoc> {
   const root = _.clone(root0);
   const accumulatedImports: ImportRecord[] = [];
   await loadImports(root, rootDocLocation, accumulatedImports, importLoader);
-  return transformPostImports(root, rootDocLocation, accumulatedImports);
+  return transformPostImports(root, rootDocLocation, accumulatedImports, omitMetadata);
 };
-

--- a/src/tests/support.ts
+++ b/src/tests/support.ts
@@ -6,7 +6,7 @@ import * as jsyaml from 'js-yaml';
 
 export async function transform(input0: any, inputLoader = pre.readFromImportLocation) {
   const input = _.isString(input0) ? yaml.loadString(input0, 'root') : input0;
-  return pre.transform(input, "root", inputLoader);
+  return pre.transform(input, "root", false, inputLoader);
 }
 
 export function transformNoImport(input0: any, accumulatedImports = []) {


### PR DESCRIPTION
This allows `iidy create-stack` and `iidy update-stack` to use approved templates when `ApprovedTemplateLocation` is set. This also reorganizes the template approval commands into a sub command: `iidy template-approval request stack-args.yaml` and `iidy template-approval review s3://...`.