### PR TITLE
Load correct module for param sub command

### DIFF
--- a/src/params/cli.ts
+++ b/src/params/cli.ts
@@ -10,7 +10,7 @@ export interface ParamCommands {
 }
 
 const lazyLoad = (fnname: keyof ParamCommands): Handler =>
-  (args) => require('../preprocess')[fnname](args);
+  (args) => require('../params')[fnname](args);
 
 const lazy: ParamCommands = {
   setParam: lazyLoad('setParam'),


### PR DESCRIPTION
`iidy param ...` commands produce error in v1.6.0.