### PR TITLE
prevent js-yaml.dump from line-wrapping strings

### DIFF
--- a/src/yaml.ts
+++ b/src/yaml.ts
@@ -194,6 +194,6 @@ export const loadString = (content: string | Buffer, filename: string): any =>
   jsyaml.safeLoad(content.toString(), {schema: schema, filename: filename});
 
 export const dump = (doc: object): string =>
-  jsyaml.safeDump(doc, {schema: schema})
+  jsyaml.safeDump(doc, {schema: schema, lineWidth: 999})
     .replace(/!<!([^>]+?)>/g, '!$1')
     .replace(/ !\$include /g, ' !$ ');


### PR DESCRIPTION
by setting the lineWidth to 999.

js-yaml was converting strings with lines longer than 80 columns into the `>` yaml string encoding, whereas we prefer `|` with no line-wrapping.