### PR TITLE
improve the detection of stack-args.yaml in `iidy render`

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -13,10 +13,10 @@ import {logger} from './logger';
 import {search} from 'jmespath';
 
 export function isStackArgsFile(location: string, doc: any): boolean {
-  if (_.includes(['stack-args.yaml', 'stack-args.yml'], pathmod.basename(location))) {
+  if (pathmod.basename(location).match(/stack-args/)) {
     return true;
   } else {
-    return doc.Template && (doc.Parameters || doc.Tags || doc.StackName);
+    return doc && doc.Template && (doc.Parameters || doc.Tags || doc.StackName);
   }
 }
 


### PR DESCRIPTION
- detect more variations of `stack-args.yaml` naming
- protect against empty documents (this lead to 'undefined has no property Template' errors)