### PR TITLE
add iidy.region and .environment to `iidy render` envs for all files

### DIFF
--- a/src/cfn/index.ts
+++ b/src/cfn/index.ts
@@ -863,14 +863,19 @@ export async function _loadStackArgs(argsfile: string, argv: GenericCLIArguments
     runCommandSet(argsdata.CommandsBefore);
   }
   if (environment) {
-    argsdata.$envValues = _.merge({}, argsdata.$envValues, {environment});
     if (!_.get(argsdata, ['Tags', 'environment'])) {
       argsdata.Tags = _.merge({environment}, argsdata.Tags);
     }
   }
-  if (getCurrentAWSRegion()) {
-    argsdata.$envValues = _.merge({}, argsdata.$envValues, {region: getCurrentAWSRegion()});
-  }
+  const finalRegion = getCurrentAWSRegion();
+  argsdata.$envValues = _.merge(
+    {}, argsdata.$envValues, {
+      // TODO deprecate bare region/environment:
+      region: finalRegion,
+      environment,
+      // new style with namespace to avoid clashes:
+      iidy: {environment, region: finalRegion}});
+
   const stackArgs = await transform(argsdata, argsfile) as StackArgs;
   logger.debug('argsdata -> stackArgs', argsdata, '\n', stackArgs);
   return stackArgs;

--- a/src/render.ts
+++ b/src/render.ts
@@ -10,7 +10,7 @@ import * as yaml from './yaml';
 import {transform} from './preprocess';
 import {_loadStackArgs} from './cfn';
 import {logger} from './logger';
-
+import getCurrentAWSRegion from './getCurrentAWSRegion';
 import {GlobalArguments} from './cli';
 
 export function isStackArgsFile(location: string, doc: any): boolean {
@@ -40,6 +40,8 @@ export async function renderMain(argv: RenderArguments): Promise<number> {
     // TODO remove the cast to any below after tightening the args on _loadStackArgs
     outputDoc = await _loadStackArgs(rootDocLocation, argv as any);
   } else {
+    // injection of $region / $environment is handled by _loadStackArgs in the if branch above
+    input.$envValues = _.merge({}, input.$envValues, {iidy: {environment: argv.environment, region: getCurrentAWSRegion()}});
     outputDoc = await transform(input, rootDocLocation);
   }
   if (argv.query) {


### PR DESCRIPTION
This previously only worked for stack-args.yaml and the names were
`environment` and `region`. These are now injected for all files, but
with a namespace wrapper to avoid clashes with user defined vars.

The previous unprefixed names are still available in stack-args.yaml
for now.