### PR TITLE
Add iidy.environment and iidy.region in Template: render:...

### DIFF
--- a/src/approval/index.ts
+++ b/src/approval/index.ts
@@ -23,7 +23,7 @@ export async function request(argv: RequestArguments): Promise<number> {
 
   if (typeof stackArgs.ApprovedTemplateLocation === "string" && stackArgs.ApprovedTemplateLocation.length > 0) {
     const s3 = new S3();
-    const s3Args = await approvedTemplateVersionLocation(stackArgs.ApprovedTemplateLocation, stackArgs.Template, argv.argsfile);
+    const s3Args = await approvedTemplateVersionLocation(stackArgs.ApprovedTemplateLocation, stackArgs.Template, argv.argsfile, argv.environment);
 
     try {
       await s3.headObject(s3Args).promise();
@@ -31,8 +31,7 @@ export async function request(argv: RequestArguments): Promise<number> {
     } catch (e) {
       if (e.code === "NotFound") {
         s3Args.Key = `${s3Args.Key}.pending`
-        const omitMetdata = true;
-        const cfnTemplate = await loadCFNTemplate(stackArgs.Template, argv.argsfile, omitMetdata);
+        const cfnTemplate = await loadCFNTemplate(stackArgs.Template, argv.argsfile, argv.environment, {omitMetadata: true});
         await s3.putObject({
           Body: cfnTemplate.TemplateBody,
           ...s3Args

--- a/src/preprocess/index.ts
+++ b/src/preprocess/index.ts
@@ -50,6 +50,10 @@ function interpolateHandlebarsString(templateString: string, env: object, errorC
 
 export type SHA256Digest = string;
 
+export type PreprocessOptions = {
+  omitMetadata?: boolean
+};
+
 export interface CfnDoc {
   AWSTemplateFormatVersion?: '2010-09-09',
   Description?: string,
@@ -1195,11 +1199,11 @@ export function transformPostImports(
   root: ExtendedCfnDoc,
   rootDocLocation: ImportLocation,
   accumulatedImports: ImportRecord[],
-  omitMetadata = false
+  options: PreprocessOptions = {}
 )
 : CfnDoc {
     let globalAccum: CfnDoc;
-    if(omitMetadata) {
+    if(options.omitMetadata) {
       globalAccum = {};
     } else {
       // TODO add the rootDoc to the Imports record
@@ -1258,12 +1262,12 @@ export function transformPostImports(
 export async function transform(
   root0: ExtendedCfnDoc,
   rootDocLocation: ImportLocation,
-  omitMetadata = false,
+  options: PreprocessOptions = {},
   importLoader = readFromImportLocation // for mocking in tests
 )
   : Promise<CfnDoc> {
   const root = _.clone(root0);
   const accumulatedImports: ImportRecord[] = [];
   await loadImports(root, rootDocLocation, accumulatedImports, importLoader);
-  return transformPostImports(root, rootDocLocation, accumulatedImports, omitMetadata);
+  return transformPostImports(root, rootDocLocation, accumulatedImports, options);
 };

--- a/src/tests/support.ts
+++ b/src/tests/support.ts
@@ -7,7 +7,7 @@ import * as jsyaml from 'js-yaml';
 
 export async function transform(input0: any, inputLoader = pre.readFromImportLocation) {
   const input = _.isString(input0) ? yaml.loadString(input0, 'root') : input0;
-  return pre.transform(input, "root", false, inputLoader);
+  return pre.transform(input, "root", {}, inputLoader);
 }
 
 export function transformNoImport(input0: any, accumulatedImports = []) {


### PR DESCRIPTION
Fixes #82 

This PR:
- adds `iidy.environment` and `iidy.region` when using `Template: render:cfn-template.yaml`
- cleans up `omitMetadata` into an "options" object