### PR TITLE
Improve command metadata

### DIFF
--- a/src/cfn/index.ts
+++ b/src/cfn/index.ts
@@ -1074,6 +1074,7 @@ abstract class AbstractCloudFormationStackCommand {
 
     const iamIdent = await iamIdentPromise;
     printSectionEntry('Current IAM Principal:', cli.blackBright(iamIdent.Arn));
+    printSectionEntry('iidy Version:', cli.blackBright(require('../../package.json').version));
 
     console.log();
   }

--- a/src/cfn/index.ts
+++ b/src/cfn/index.ts
@@ -1057,6 +1057,7 @@ abstract class AbstractCloudFormationStackCommand {
   async _showCommandSummary() {
     const sts = new aws.STS();
     const iamIdentPromise = sts.getCallerIdentity().promise();
+    const roleARN = this.stackArgs.ServiceRoleARN || this.stackArgs.RoleARN;
 
     console.log(); // blank line
     console.log(formatSectionHeading('Command Metadata:'))
@@ -1069,7 +1070,7 @@ abstract class AbstractCloudFormationStackCommand {
       'CLI Arguments:',
       cli.blackBright(prettyFormatSmallMap(_.pick(this.argv, ['region', 'profile', 'argsfile']))));
 
-    printSectionEntry('IAM Service Role:', cli.blackBright(def('None', this.stackArgs.RoleARN)));
+    printSectionEntry('IAM Service Role:', cli.blackBright(def('None', roleARN)));
 
     const iamIdent = await iamIdentPromise;
     printSectionEntry('Current IAM Principal:', cli.blackBright(iamIdent.Arn));


### PR DESCRIPTION
This PR:
- fixes an issue where `ServiceRoleARN` would not be shown in Command Metadata
- adds iidy's version to Command Metadata