### PR TITLE
add envvar LOG_IIDY_ERROR to control stack trace logging

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -53,7 +53,7 @@ export const wrapCommandHandler = (handler: Handler) =>
         if (error.message) {
           logger.error(error.message);
         }
-        if (debug()) {
+        if (debug() || process.env.LOG_IIDY_ERROR) {
           logger.error(error);
         }
         process.exit(1);


### PR DESCRIPTION
Using the invocation `LOG_IIDY_ERROR=1 iidy ...` will print full stack traces rather than just the error description.