### PR TITLE
Get stack name from stack args

### DIFF
--- a/src/cfn/index.ts
+++ b/src/cfn/index.ts
@@ -1061,6 +1061,7 @@ abstract class AbstractCloudFormationStackCommand {
     console.log(); // blank line
     console.log(formatSectionHeading('Command Metadata:'))
     printSectionEntry('CFN Operation:', cli.magenta(this.cfnOperation));
+    printSectionEntry('iidy Environment:', cli.magenta(this.environment));
     printSectionEntry('Region:', cli.magenta(this.region));
     if (!_.isEmpty(this.profile)) {
       printSectionEntry('Profile:', cli.magenta(this.profile));

--- a/src/cfn/index.ts
+++ b/src/cfn/index.ts
@@ -1578,20 +1578,24 @@ export async function getStackTemplateMain(argv: GenericCLIArguments): Promise<n
 ////////////////////////////////////////////////////////////////////////////////
 
 export async function deleteStackMain(argv: GenericCLIArguments): Promise<number> {
-  await configureAWS(argv);
+  const StackName = await getStackNameFromArgsAndConfigureAWS(argv);
   const region = getCurrentAWSRegion();
-
-  const StackName = argv.stackname;
 
   const stackPromise = getStackDescription(StackName);
   try {
     await stackPromise;
   } catch (e) {
+    const sts = new aws.STS();
+    const iamIdent = await sts.getCallerIdentity().promise();
+    const msg = `The stack ${cli.magenta(StackName)} is absent in env = ${cli.yellow(argv.environment)}:
+      region = ${cli.blackBright(region)}
+      account = ${cli.blackBright(iamIdent.Account)}
+      auth_arn = ${cli.blackBright(iamIdent.Arn)}`;
     if (argv.failIfAbsent) {
-      logger.error(`The stack ${StackName} is absent.`);
+      logger.error(msg);
       return 1;
     } else {
-      logger.info(`The stack ${StackName} is absent.`);
+      logger.info(msg);
       return 0;
     }
   }

--- a/src/cfn/index.ts
+++ b/src/cfn/index.ts
@@ -863,11 +863,10 @@ export async function _loadStackArgs(argsfile: string, argv: GenericCLIArguments
       throw new Error(`The ${key} setting in stack-args.yaml must be a plain string or an environment map of strings.`);
     }
   }
-  // have to do it before the call to transform
-  // note, the aws settings in argv trump those from argsdata
-  await configureAWS(_.merge(
-    {profile: argsdata.Profile, assumeRoleArn: argsdata.AssumeRoleARN, region: argsdata.Region},
-    argv)); // tslint:disable-line
+  // have to configureAws  before the call to transform
+  const cliOptionOverrides = _.pickBy(argv, (v: any, k: string) => !_.isEmpty(v) && _.includes(['region', 'profile', 'assumeRoleArn'], k));
+  const argsfileSettings = {profile: argsdata.Profile, assumeRoleArn: argsdata.AssumeRoleARN, region: argsdata.Region};
+  await configureAWS(_.merge(argsfileSettings, cliOptionOverrides)); // cliOptionOverrides trump argsfile
 
   if (argsdata.CommandsBefore) {
     // TODO improve CLI output of this and think about adding

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -238,7 +238,7 @@ export function buildArgs(commands = lazy, wrapMainHandler = wrapCommandHandler)
         type: 'number', default: 50,
         description: description('how many stack events to display')
       })
-      .usage('Usage: iidy describe-stack <stackname>'),
+      .usage('Usage: iidy describe-stack <stackname-or-argsfile>'),
     wrapMainHandler(commands.describeStackMain))
 
     .command(
@@ -250,7 +250,7 @@ export function buildArgs(commands = lazy, wrapMainHandler = wrapCommandHandler)
         type: 'number', default: (60 * 3),
         description: description('how long to wait for events when the stack is in a terminal state')
       })
-      .usage('Usage: iidy watch-stack <stackname>'),
+      .usage('Usage: iidy watch-stack <stackname-or-argsfile>'),
     wrapMainHandler(commands.watchStackMain))
 
     .command(
@@ -275,7 +275,7 @@ export function buildArgs(commands = lazy, wrapMainHandler = wrapCommandHandler)
         type: 'boolean', default: false,
         description: 'Fail if stack is absent (exit code = 1). Default is to tolerate absence.'
       })
-      .usage('Usage: iidy delete-stack <stackname>'),
+      .usage('Usage: iidy delete-stack <stackname-or-argsfile>'),
     wrapMainHandler(commands.deleteStackMain))
 
     .command(
@@ -293,7 +293,7 @@ export function buildArgs(commands = lazy, wrapMainHandler = wrapCommandHandler)
         choices: ['Original', 'Processed'],
         description: description('Template stage to show')
       })
-      .usage('Usage: iidy get-stack-template <stackname>'),
+      .usage('Usage: iidy get-stack-template <stackname-or-argsfile>'),
     wrapMainHandler(commands.getStackTemplateMain))
 
     .command(
@@ -305,7 +305,7 @@ export function buildArgs(commands = lazy, wrapMainHandler = wrapCommandHandler)
         type: 'boolean', default: false,
         description: description('Show only instance dns names')
       })
-      .usage('Usage: iidy get-stack-instances <stackname>'),
+      .usage('Usage: iidy get-stack-instances <stackname-or-argsfile>'),
     wrapMainHandler(commands.getStackInstancesMain))
 
     .command(


### PR DESCRIPTION
let describe-stack (etc.) read stack name from stack-args.yaml

This applies to describe-stack, watch-stack, delete-stack,
get-stack-template, get-stack-instances.

These commands will detect if you've provided a .yaml or .yml file as
the `stackname` argument and a file of that name exists.