### PR TITLE
Support handlebars templates in `stack-args.yaml:CommandsBefore`

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,11 @@ Template: <local file path or s3 path>
 Region: <aws region name>
 
 Profile: <aws profile name>
+# or
+AssumeRoleARN: arn:aws:iam::<account>:role/<rolename>
+
+# CloudFormation ServiceRole
+ServiceRoleARN: arn:aws:iam::<account>:role/<rolename>
 
 Tags: # aws tags to apply to the stack
   owner: Tavis
@@ -162,9 +167,6 @@ Capabilities: # optional list. *Preferably empty*
 
 NotificationARNs:
   - <sns arn>
-
-# CloudFormation ServiceRole
-ServiceRoleARN: arn:aws:iam::<acount>:role/<rolename>
 
 TimeoutInMinutes: <number>
 

--- a/README.md
+++ b/README.md
@@ -176,8 +176,13 @@ StackPolicy: <local file path or s3 path>
 ResourceTypes: <list of aws resource types allowed in the template>
   # see http://docs.aws.amazon.com/cli/latest/reference/cloudformation/create-stack.html#options
 
-CommandsBefore: # shell commands to run prior the cfn stack operation
-  - make build # for example
+CommandsBefore:
+  # a list of shell commands to run prior the cfn stack operation
+  # /bin/bash is used if found.
+  # handlebars templates in the command strings are preprocessed prior to execution.
+
+  # E.g.
+  - make build
 
 ```
 

--- a/src/cfn/index.ts
+++ b/src/cfn/index.ts
@@ -1778,9 +1778,13 @@ export async function deleteStackMain(argv: GenericCLIArguments): Promise<number
   }
   if (confirmed) {
     const cfn = new aws.CloudFormation();
-    // TODO --client-request-token
     const startTime = await getReliableStartTime();
-    await cfn.deleteStack({StackName, RoleARN: argv.roleArn, RetainResources: argv.retainResources}).promise();
+    await cfn.deleteStack({
+      StackName,
+      RoleARN: argv.roleArn,
+      RetainResources: argv.retainResources,
+      ClientRequestToken: argv.clientRequestToken
+    }).promise();
     await watchStack(StackId, startTime);
     console.log();
     const {StackStatus} = await getStackDescription(StackId);

--- a/src/cfn/index.ts
+++ b/src/cfn/index.ts
@@ -558,7 +558,7 @@ function runCommandSet(commands: string[], cwd: string, handleBarsEnv?: object):
         },
         process.env)
     };
-    console.log('--', `Output ${index + 1}`, '-'.repeat(25));
+    console.log('--', `Command ${index + 1} Output`, '-'.repeat(25));
     const result = child_process.spawnSync(expandedCommand, [], spawnOptions);
     if (result.status > 0) {
       throw new Error(`Error running command (exit code ${result.status}):\n` + command);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -180,6 +180,10 @@ export function buildArgs(commands = lazy, wrapMainHandler = wrapCommandHandler)
         type: 'boolean', default: false,
         description: description('review & confirm changes via a changeset')
       })
+      .option('yes', {
+        type: 'boolean', default: false,
+        description: description('Confirm and execute changeset if --changeset option is used')
+      })
       .option('diff', {
         type: 'boolean', default: true,
         description: description('diff & review changes to the template body as part of changeset review')
@@ -196,7 +200,23 @@ export function buildArgs(commands = lazy, wrapMainHandler = wrapCommandHandler)
     (args) => args
       .demandCommand(0, 0)
       .usage('Usage: iidy create-or-update <stack-args.yaml>')
-      .option('stack-name', stackNameOpt),
+      .option('stack-name', stackNameOpt)
+      .option('changeset', {
+        type: 'boolean', default: false,
+        description: description('review & confirm changes via a changeset')
+      })
+      .option('yes', {
+        type: 'boolean', default: false,
+        description: description('Confirm and execute changeset if --changeset option is used')
+      })
+      .option('diff', {
+        type: 'boolean', default: true,
+        description: description('diff & review changes to the template body as part of changeset review')
+      })
+      .option('stack-policy-during-update', {
+        type: 'string', default: null,
+        description: description('override original stack-policy for this update only')
+      }),
     wrapMainHandler(commands.createOrUpdateStackMain))
 
     .command(
@@ -216,7 +236,7 @@ export function buildArgs(commands = lazy, wrapMainHandler = wrapCommandHandler)
       .demandCommand(0, 0)
       .option('watch', {
         type: 'boolean', default: false,
-        description: 'Watch stack after creating changeset. This is useful when exec-changeset is called by others.'
+        description: description('Watch stack after creating changeset. This is useful when exec-changeset is called by others.')
       })
       .option('watch-inactivity-timeout', {
         type: 'number', default: (60 * 3),
@@ -271,7 +291,7 @@ export function buildArgs(commands = lazy, wrapMainHandler = wrapCommandHandler)
       .demandCommand(0, 0)
       .option('role-arn', {
         type: 'string',
-        description: 'Role to assume for delete operation'
+        description: description('Role to assume for delete operation')
       })
       .option('retain-resources', {
         type: 'string',
@@ -280,11 +300,11 @@ export function buildArgs(commands = lazy, wrapMainHandler = wrapCommandHandler)
       })
       .option('yes', {
         type: 'boolean', default: false,
-        description: 'Confirm deletion of stack'
+        description: description('Confirm deletion of stack')
       })
       .option('fail-if-absent', {
         type: 'boolean', default: false,
-        description: 'Fail if stack is absent (exit code = 1). Default is to tolerate absence.'
+        description: description('Fail if stack is absent (exit code = 1). Default is to tolerate absence.')
       })
       .usage('Usage: iidy delete-stack <stackname-or-argsfile>'),
     wrapMainHandler(commands.deleteStackMain))

--- a/src/filehash.ts
+++ b/src/filehash.ts
@@ -1,0 +1,21 @@
+import * as fs from 'fs';
+import * as pathmod from 'path';
+import * as child_process from 'child_process';
+
+import normalizePath from './normalizePath';
+
+/** Calculate a sha256 hash of a file or directory. */
+export default (path0: string) => {
+  const path = normalizePath(path0);
+  // this assumes local files/dirs TODO validate that
+  if (!fs.existsSync(path)) {
+    throw new Error(`Invalid path ${path} for filehash`);
+  }
+  const isDir = fs.lstatSync(path).isDirectory();
+  const shasumCommand = 'shasum -p -a 256';
+  const hashCommand = isDir
+    ? `find ${path} -type f -print0 | xargs -0 ${shasumCommand} | ${shasumCommand}`
+    : `${shasumCommand} ${path}`;
+  const result = child_process.spawnSync(hashCommand, [], {shell: true});
+  return result.stdout.toString().trim().split(' ')[0];
+}

--- a/src/filehash.ts
+++ b/src/filehash.ts
@@ -5,7 +5,7 @@ import * as child_process from 'child_process';
 import normalizePath from './normalizePath';
 
 /** Calculate a sha256 hash of a file or directory. */
-export default (path0: string) => {
+export default (path0: string, format: 'hex'|'base64' = 'hex') => {
   const path = normalizePath(path0);
   // this assumes local files/dirs TODO validate that
   if (!fs.existsSync(path)) {
@@ -16,6 +16,13 @@ export default (path0: string) => {
   const hashCommand = isDir
     ? `find ${path} -type f -print0 | xargs -0 ${shasumCommand} | ${shasumCommand}`
     : `${shasumCommand} ${path}`;
+
   const result = child_process.spawnSync(hashCommand, [], {shell: true});
-  return result.stdout.toString().trim().split(' ')[0];
+  const hexHash = result.stdout.toString().trim().split(' ')[0];
+  switch (format) {
+    case 'hex':
+      return hexHash;
+    case 'base64':
+      return Buffer.from(hexHash, 'hex').toString('base64');
+  }
 }

--- a/src/normalizePath.ts
+++ b/src/normalizePath.ts
@@ -1,0 +1,14 @@
+import * as pathmod from 'path';
+import * as _ from 'lodash';
+
+function resolveHome(path: string): string {
+  if (path[0] === '~') {
+    return pathmod.join(process.env.HOME as string, path.slice(1));
+  } else {
+    return path;
+  }
+}
+
+/** Resolves ~/ in path segments then applies path.resolve to join and normalize the segments. */
+export default (...pathSegments: string[]): string =>
+  pathmod.resolve.apply(pathmod, _.map(pathSegments, (path) => resolveHome(path.trim())));

--- a/src/preprocess/index.ts
+++ b/src/preprocess/index.ts
@@ -36,7 +36,7 @@ const CFN_SUB_RE = /\${([^!].*?)}/g;
 
 handlebars.registerHelper('tojson', (context: any) => JSON.stringify(context));
 handlebars.registerHelper('toyaml', (context: any) => yaml.dump(context));
-handlebars.registerHelper('base64', (context: any) => new Buffer(context).toString('base64'));
+handlebars.registerHelper('base64', (context: any) => Buffer.from(context).toString('base64'));
 handlebars.registerHelper('toLowerCase', (str: string) => str.toLowerCase());
 handlebars.registerHelper('toUpperCase', (str: string) => str.toUpperCase());
 

--- a/src/preprocess/index.ts
+++ b/src/preprocess/index.ts
@@ -26,6 +26,7 @@ import * as tv4 from 'tv4';
 
 import * as yaml from '../yaml';
 import {logger} from '../logger';
+import normalizePath from '../normalizePath';
 import paginateAwsCall from '../paginateAwsCall';
 import {_getParamsByPath} from '../params';
 
@@ -158,17 +159,6 @@ function gitValue(valueType: GitValue): string {
 
 const sha256Digest = (content: string | Buffer): SHA256Digest =>
   crypto.createHash('sha256').update(content.toString()).digest('hex');
-
-function resolveHome(path: string): string {
-  if (path[0] === '~') {
-    return pathmod.join(process.env.HOME as string, path.slice(1));
-  } else {
-    return path;
-  }
-}
-
-const normalizePath = (...pathSegments: string[]): string =>
-  pathmod.resolve.apply(pathmod, _.map(pathSegments, (path) => resolveHome(path.trim())));
 
 const _isPlainMap = (node: any): node is object =>
   _.isObject(node) &&

--- a/src/preprocess/index.ts
+++ b/src/preprocess/index.ts
@@ -685,6 +685,7 @@ function validateTemplateParameter(param: $param, mergedParams: any, name: strin
       case 'AWS::SSM::Parameter::Value<String>':
       case 'AWS::SSM::Parameter::Value<List<String>>':
       case 'AWS::SSM::Parameter::Value<CommaDelimitedList>':
+        // TODO add the rest of the SSM types
         // TODO validate these
         break
       default:

--- a/src/preprocess/index.ts
+++ b/src/preprocess/index.ts
@@ -40,11 +40,12 @@ handlebars.registerHelper('base64', (context: any) => new Buffer(context).toStri
 handlebars.registerHelper('toLowerCase', (str: string) => str.toLowerCase());
 handlebars.registerHelper('toUpperCase', (str: string) => str.toUpperCase());
 
-function interpolateHandlebarsString(templateString: string, env: object, errorContext: string) {
+export function interpolateHandlebarsString(templateString: string, env: object, errorContext: string) {
   try {
     const template = handlebars.compile(templateString, {noEscape: true, strict: true});
     return template(env);
   } catch (e) {
+    logger.debug(e);
     throw new Error(
       `Error in string template at ${errorContext}:\n       ${e.message}\n       Template: ${templateString}`)
   }

--- a/src/preprocess/index.ts
+++ b/src/preprocess/index.ts
@@ -147,7 +147,7 @@ const gitValues = ["branch", "describe", "sha"];
 function gitValue(valueType: GitValue): string {
   const command = {
     branch: 'git rev-parse --abbrev-ref HEAD',
-    describe: 'git describe --dirty',
+    describe: 'git describe --dirty --tags',
     sha: 'git rev-parse HEAD'
   }[valueType];
 

--- a/src/preprocess/index.ts
+++ b/src/preprocess/index.ts
@@ -466,7 +466,7 @@ export async function readFromImportLocation(location: ImportLocation, baseLocat
   return _.merge({importType}, importData);
 }
 
-async function loadImports(
+export async function loadImports(
   doc: ExtendedCfnDoc,
   baseLocation: ImportLocation,
   importsAccum: ImportRecord[],

--- a/src/preprocess/index.ts
+++ b/src/preprocess/index.ts
@@ -27,6 +27,7 @@ import * as tv4 from 'tv4';
 import * as yaml from '../yaml';
 import {logger} from '../logger';
 import normalizePath from '../normalizePath';
+import filehash from '../filehash';
 import paginateAwsCall from '../paginateAwsCall';
 import {_getParamsByPath} from '../params';
 
@@ -261,18 +262,11 @@ export const importLoaders: {[key in ImportType]: ImportLoader} = {
   },
 
   filehash: async (location, baseLocation) => {
-    // this assumes local files/dirs TODO validate that
     const resolvedLocation = normalizePath(pathmod.dirname(baseLocation), location.split(':')[1]);
     if (!fs.existsSync(resolvedLocation)) {
       throw new Error(`Invalid location ${resolvedLocation} for filehash in ${baseLocation}`);
     }
-    const isDir = fs.lstatSync(resolvedLocation).isDirectory();
-    const shasumCommand = 'shasum -p -a 256';
-    const hashCommand = isDir
-      ? `find ${resolvedLocation} -type f -print0 | xargs -0 ${shasumCommand} | ${shasumCommand}`
-      : `${shasumCommand} ${resolvedLocation}`;
-    const result = child_process.spawnSync(hashCommand, [], {shell: true});
-    const data = result.stdout.toString().trim().split(' ')[0];
+    const data = filehash(resolvedLocation);
     return {resolvedLocation, data, doc: data};
   },
 

--- a/src/preprocess/index.ts
+++ b/src/preprocess/index.ts
@@ -985,7 +985,7 @@ function visit$mergeMap(node: yaml.$mergeMap, path: string, env: Env): AnyButUnd
 
 function visit$concat(node: yaml.$concat, path: string, env: Env): AnyButUndefined[] {
   const error = new Error(`Invalid argument to $concat at "${path}".`
-      + " Must be array of arrays.")
+    + " Must be array of arrays.")
 
   if (!_.isArray(node.data)) {
     throw error;

--- a/src/render.ts
+++ b/src/render.ts
@@ -22,7 +22,7 @@ export function isStackArgsFile(location: string, doc: any): boolean {
   }
 }
 
-export type RenderArguments = GlobalArguments & {
+export type RenderArguments = GlobalArguments & Arguments & {
   template: string;
   outfile: string;
   overwrite: boolean;
@@ -41,8 +41,15 @@ export async function renderMain(argv: RenderArguments): Promise<number> {
     // TODO remove the cast to any below after tightening the args on _loadStackArgs
     outputDoc = await _loadStackArgs(rootDocLocation, argv as any);
   } else {
-    // injection of $region / $environment is handled by _loadStackArgs in the if branch above
-    input.$envValues = _.merge({}, input.$envValues, {iidy: {environment: argv.environment, region: getCurrentAWSRegion()}});
+    // injection of iidy env is handled by _loadStackArgs in the if branch above
+    input.$envValues = _.merge({}, input.$envValues, {
+      iidy: {
+        command: argv._.join(' '),
+        environment: argv.environment,
+        region: getCurrentAWSRegion()
+        // NOTE: missing profile which is present in stackArgs rendering
+      }
+    });
     outputDoc = await transform(input, rootDocLocation);
   }
   if (argv.query) {

--- a/src/tests/test-aws-configuration.ts
+++ b/src/tests/test-aws-configuration.ts
@@ -87,8 +87,9 @@ if (awsUserDir && fs.existsSync(awsUserDir)) {
 
       }
 
+      const testProfiles = ['sandbox']; // add more here to test for state bugs
       it("handles the profile argument", async () => {
-        for (const profile of _.intersection(availableProfileNames, ['sandbox', 'staging'])) {
+        for (const profile of _.intersection(availableProfileNames, testProfiles)) {
           const roleToAssume = awsConfigIni.getProfile(profile).role_arn;
           await configureAWS({profile});
           await assertRoleAssumed(roleToAssume);
@@ -96,7 +97,7 @@ if (awsUserDir && fs.existsSync(awsUserDir)) {
       });
 
       it("handles the assumeRoleArn argument", async () => {
-        for (const profile of _.intersection(availableProfileNames, ['sandbox', 'staging'])) {
+        for (const profile of _.intersection(availableProfileNames, testProfiles)) {
           const roleToAssume = awsConfigIni.getProfile(profile).role_arn;
           await configureAWS({assumeRoleArn: roleToAssume});
           await assertRoleAssumed(roleToAssume);

--- a/src/tests/test-yaml-preprocessing.ts
+++ b/src/tests/test-yaml-preprocessing.ts
@@ -251,7 +251,7 @@ aref: !$ nested.aref`, mockLoader)).to.deep.equal({aref: 'mock'});
           .to.deep.equal({out: 'YWJj'});
         const longerString = "abc ".repeat(20);
         expect(await transform({$defs: {a: longerString}, out: '{{base64 a}}'}))
-          .to.deep.equal({out: new Buffer(longerString).toString('base64')});
+          .to.deep.equal({out: Buffer.from(longerString).toString('base64')});
       });
 
     });


### PR DESCRIPTION
**Merge after #113**

- Support handlebars templates in `stack-args.yaml:CommandsBefore`
- explicitly set the cwd for CommandsBefore to the directory
  containing stack-args.yaml. This was always the current directory previously.
- explicitly set the shell to /bin/bash if present
- add `iidy.profile` and `iidy.command` the stack-args preprocessor
  namespace.
- adds `filehash` as a handlebars helper available in CommandsBefore
- exposes `iidy.stackArgs`, `iidy.stackName`, and any $imports / $defs
  from the stack-args to handlebars in CommandsBefore
- improves the logging of the commands & their output
- restrict execution of CommandsBefore to `create-stack`, `update-stack`, `create-or-update`, and `create-changeset`

Note, `iidy render stack-args.yaml` will currently strip out CommandsBefore but we could enhance this in the future to show the value of CommandsBefore after preprocessing the handlebars templates but without running the commands.