### PR TITLE
Changesets on create-or-update

### DIFF
--- a/src/cfn/index.ts
+++ b/src/cfn/index.ts
@@ -1019,6 +1019,11 @@ async function isHttpTemplateAccessible(location?: string) {
   }
 }
 
+export async function doesStackExist(StackName: string): Promise<boolean> {
+  const cfn = new aws.CloudFormation();
+  return await cfn.describeStacks({StackName}).promise().thenReturn(true).catchReturn(false);
+}
+
 abstract class AbstractCloudFormationStackCommand {
   public region: AWSRegion
 
@@ -1216,35 +1221,6 @@ class UpdateStack extends AbstractCloudFormationStackCommand {
   }
 }
 
-class CreateOrUpdateStack extends AbstractCloudFormationStackCommand {
-  stackExists: boolean;
-  showPreviousEvents = false;
-
-  async _setup() {
-    await super._setup();
-    this.stackExists = await this.cfn.describeStacks({StackName: this.stackName}).promise()
-      .return(true).catchReturn(false);
-    if (this.stackExists) {
-      this.cfnOperation = 'UPDATE_STACK';
-      this.expectedFinalStackStatus = ['UPDATE_COMPLETE'];
-      this.previousStackEventsPromise = getAllStackEvents(this.stackName);
-      this.showPreviousEvents = true;
-    } else {
-      this.cfnOperation = 'CREATE_STACK';
-      this.expectedFinalStackStatus = ['CREATE_COMPLETE'];
-      this.showTimesInSummary = false;
-    }
-  }
-
-  async _run() {
-    if (this.stackExists) {
-      return this._runUpdate();
-    } else {
-      return this._runCreate();
-    }
-  }
-}
-
 function summarizeChangeSet(changeSet: aws.CloudFormation.DescribeChangeSetOutput) {
   const indent = '   ';
   for (const change of changeSet.Changes || []) {
@@ -1311,7 +1287,7 @@ class CreateChangeSet extends AbstractCloudFormationStackCommand {
     const StackName = createChangeSetInput.StackName;
     createChangeSetInput.Description = this.argv.description;
 
-    const stackExists = await this.cfn.describeStacks({StackName}).promise().thenReturn(true).catchReturn(false);
+    const stackExists = await doesStackExist(StackName);
     createChangeSetInput.ChangeSetType = stackExists ? 'UPDATE' : 'CREATE';
 
     if (await this._requiresTemplateApproval(createChangeSetInput.TemplateURL)) {
@@ -1414,7 +1390,6 @@ const wrapCommandCtor =
     }
 
 export const createStackMain = wrapCommandCtor(CreateStack);
-export const createOrUpdateStackMain = wrapCommandCtor(CreateOrUpdateStack);
 export const executeChangesetMain = wrapCommandCtor(ExecuteChangeSet);
 export const estimateCost = wrapCommandCtor(EstimateStackCost);
 
@@ -1446,10 +1421,54 @@ export async function diffStackTemplates(StackName: string, stackArgs: StackArgs
     diff(yaml.dump(oldTemplate), yaml.dump(newTemplate))
   }
 }
+export async function createOrUpdateStackMain(argv: GenericCLIArguments): Promise<number> {
+  const stackArgs = await loadStackArgs(argv);
+  const StackName = argv.stackName || stackArgs.StackName;
+  const stackExists = await doesStackExist(StackName);
+  if (stackExists) {
+    return updateStackMain(argv, stackArgs);
+  } else if (argv.changeset) {
+    // TODO extract this into a separate createStackMain fn
+    // TODO autodetect AWS::Serverless and default to changeset=true
+    const changeSetRunner = new CreateChangeSet(argv, stackArgs);
+    const createChangesetResult = await changeSetRunner.run();
+    if (createChangesetResult > 0) {
+      return createChangesetResult;
+    } else {
+      console.log()
+      return await confirmChangesetExec(argv, changeSetRunner, stackArgs);
+    }
+  } else {
+    return new CreateStack(argv, stackArgs).run();
+  }
+}
 
-export async function updateStackMain(argv: GenericCLIArguments): Promise<number> {
+async function confirmChangesetExec(argv: GenericCLIArguments, changeSetRunner: CreateChangeSet, stackArgs: StackArgs): Promise<number> {
+  let confirmed: boolean;
+  if (argv.yes) {
+    confirmed = true;
+  } else {
+    const resp = await inquirer.prompt(
+      {
+        name: 'confirm',
+        type: 'confirm', default: false,
+        message: `Do you want to execute this changeset now?`
+      })
+    confirmed = resp.confirm;
+  }
+  if (confirmed) {
+    argv.changesetName = changeSetRunner.changeSetName;
+    return new ExecuteChangeSet(argv, stackArgs).run();
+  } else {
+    console.log(`You can do so later using\n`
+      + `  iidy exec-changeset -s ${changeSetRunner.stackName} ${changeSetRunner.argsfile} ${changeSetRunner.changeSetName}`);
+    return INTERRUPT;
+  }
+}
+
+export async function updateStackMain(argv: GenericCLIArguments, stackArgs?: StackArgs): Promise<number> {
+  stackArgs = stackArgs || await loadStackArgs(argv);
   if (argv.changeset) {
-    const stackArgs = await loadStackArgs(argv);
     const region = getCurrentAWSRegion();
     const StackName = argv.stackName || stackArgs.StackName;
     const stack = await summarizeStackDefinition(StackName, region);
@@ -1472,23 +1491,9 @@ export async function updateStackMain(argv: GenericCLIArguments): Promise<number
       }
     }
     console.log()
-
-    const resp = await inquirer.prompt(
-      {
-        name: 'confirmed',
-        type: 'confirm', default: false,
-        message: `Do you want to execute this changeset now?`
-      })
-    if (resp.confirmed) {
-      argv.changesetName = changeSetRunner.changeSetName;
-      return new ExecuteChangeSet(argv, stackArgs).run();
-    } else {
-      console.log(`You can do so later using\n`
-        + `  iidy exec-changeset -s ${changeSetRunner.stackName} ${changeSetRunner.argsfile} ${changeSetRunner.changeSetName}`);
-      return INTERRUPT;
-    }
+    return await confirmChangesetExec(argv, changeSetRunner, stackArgs);
   } else {
-    return new UpdateStack(argv, await loadStackArgs(argv)).run();
+    return new UpdateStack(argv, stackArgs).run();
   }
 };
 

--- a/src/cfn/index.ts
+++ b/src/cfn/index.ts
@@ -1133,13 +1133,23 @@ abstract class AbstractCloudFormationStackCommand {
     if (_.isEmpty(this.stackArgs.Template)) {
       throw new Error('For create-stack you must provide at Template: parameter in your argsfile')
     };
-    const createStackInput = await stackArgsToCreateStackInput(this.stackArgs, this.argsfile, this.environment, this.stackName);
-    if (await this._requiresTemplateApproval(createStackInput.TemplateURL)) {
-      return this._exitWithTemplateApprovalFailure();
+    try {
+      const createStackInput = await stackArgsToCreateStackInput(this.stackArgs, this.argsfile, this.environment, this.stackName);
+      if (await this._requiresTemplateApproval(createStackInput.TemplateURL)) {
+        return this._exitWithTemplateApprovalFailure();
+      }
+      const createStackOutput = await this.cfn.createStack(createStackInput).promise();
+      await this._updateStackTerminationPolicy();
+      return this._watchAndSummarize(createStackOutput.StackId as string);
+    } catch (e) {
+      if (e.message === 'CreateStack cannot be used with templates containing Transforms.') {
+        logger.error(
+          `Your stack template contains an AWS:: Transform so you need to use 'iidy create-or-update ${cli.red('--changeset')}'`)
+        return INTERRUPT;
+      } else {
+        throw e;
+      }
     }
-    const createStackOutput = await this.cfn.createStack(createStackInput).promise();
-    await this._updateStackTerminationPolicy();
-    return this._watchAndSummarize(createStackOutput.StackId as string);
   }
 
   async _runUpdate() {
@@ -1163,6 +1173,10 @@ abstract class AbstractCloudFormationStackCommand {
       if (e.message === 'No updates are to be performed.') {
         logger.info('No changes detected so no stack update needed.');
         return SUCCESS;
+      } else if (e.message === 'UpdateStack cannot be used with templates containing Transforms.') {
+        logger.error(
+          `Your stack template contains an AWS:: Transform so you need to use 'iidy update-stack ${cli.red('--changeset')}'`)
+        return INTERRUPT;
       } else {
         throw e;
       }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -180,6 +180,10 @@ export function buildArgs(commands = lazy, wrapMainHandler = wrapCommandHandler)
         type: 'boolean', default: false,
         description: description('review & confirm changes via a changeset')
       })
+      .option('yes', {
+        type: 'boolean', default: false,
+        description: description('Confirm and execute changeset if --changeset option is used')
+      })
       .option('diff', {
         type: 'boolean', default: true,
         description: description('diff & review changes to the template body as part of changeset review')
@@ -196,7 +200,23 @@ export function buildArgs(commands = lazy, wrapMainHandler = wrapCommandHandler)
     (args) => args
       .demandCommand(0, 0)
       .usage('Usage: iidy create-or-update <stack-args.yaml>')
-      .option('stack-name', stackNameOpt),
+      .option('stack-name', stackNameOpt)
+      .option('changeset', {
+        type: 'boolean', default: false,
+        description: description('review & confirm changes via a changeset')
+      })
+      .option('yes', {
+        type: 'boolean', default: false,
+        description: description('Confirm and execute changeset if --changeset option is used')
+      })
+      .option('diff', {
+        type: 'boolean', default: true,
+        description: description('diff & review changes to the template body as part of changeset review')
+      })
+      .option('stack-policy-during-update', {
+        type: 'string', default: null,
+        description: description('override original stack-policy for this update only')
+      }),
     wrapMainHandler(commands.createOrUpdateStackMain))
 
     .command(
@@ -216,7 +236,7 @@ export function buildArgs(commands = lazy, wrapMainHandler = wrapCommandHandler)
       .demandCommand(0, 0)
       .option('watch', {
         type: 'boolean', default: false,
-        description: 'Watch stack after creating changeset. This is useful when exec-changeset is called by others.'
+        description: description('Watch stack after creating changeset. This is useful when exec-changeset is called by others.')
       })
       .option('watch-inactivity-timeout', {
         type: 'number', default: (60 * 3),
@@ -271,7 +291,7 @@ export function buildArgs(commands = lazy, wrapMainHandler = wrapCommandHandler)
       .demandCommand(0, 0)
       .option('role-arn', {
         type: 'string',
-        description: 'Role to assume for delete operation'
+        description: description('Role to assume for delete operation')
       })
       .option('retain-resources', {
         type: 'string',
@@ -280,11 +300,11 @@ export function buildArgs(commands = lazy, wrapMainHandler = wrapCommandHandler)
       })
       .option('yes', {
         type: 'boolean', default: false,
-        description: 'Confirm deletion of stack'
+        description: description('Confirm deletion of stack')
       })
       .option('fail-if-absent', {
         type: 'boolean', default: false,
-        description: 'Fail if stack is absent (exit code = 1). Default is to tolerate absence.'
+        description: description('Fail if stack is absent (exit code = 1). Default is to tolerate absence.')
       })
       .usage('Usage: iidy delete-stack <stackname-or-argsfile>'),
     wrapMainHandler(commands.deleteStackMain))


### PR DESCRIPTION
Add `--changeset` and related options to `create-or-update`.

This change involves some internal refactoring of the code that
handles the --changeset user interactions, to reduce duplication.

I've also improved the error messages when the user tries to use `AWS::Serverless` or `AWS::Include` transforms without using `--changeset`.