### PR TITLE
Improve stack-args:CommandsBefore

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,8 +178,13 @@ StackPolicy: <local file path or s3 path>
 ResourceTypes: <list of aws resource types allowed in the template>
   # see http://docs.aws.amazon.com/cli/latest/reference/cloudformation/create-stack.html#options
 
-CommandsBefore: # shell commands to run prior the cfn stack operation
-  - make build # for example
+CommandsBefore:
+  # a list of shell commands to run prior the cfn stack operation
+  # /bin/bash is used if found.
+  # handlebars templates in the command strings are preprocessed prior to execution.
+
+  # E.g.
+  - make build
 
 ```
 

--- a/src/cfn/index.ts
+++ b/src/cfn/index.ts
@@ -558,7 +558,7 @@ function runCommandSet(commands: string[], cwd: string, handleBarsEnv?: object):
         },
         process.env)
     };
-    console.log('--', `Output ${index + 1}`, '-'.repeat(25));
+    console.log('--', `Command ${index + 1} Output`, '-'.repeat(25));
     const result = child_process.spawnSync(expandedCommand, [], spawnOptions);
     if (result.status > 0) {
       throw new Error(`Error running command (exit code ${result.status}):\n` + command);

--- a/src/filehash.ts
+++ b/src/filehash.ts
@@ -1,0 +1,21 @@
+import * as fs from 'fs';
+import * as pathmod from 'path';
+import * as child_process from 'child_process';
+
+import normalizePath from './normalizePath';
+
+/** Calculate a sha256 hash of a file or directory. */
+export default (path0: string) => {
+  const path = normalizePath(path0);
+  // this assumes local files/dirs TODO validate that
+  if (!fs.existsSync(path)) {
+    throw new Error(`Invalid path ${path} for filehash`);
+  }
+  const isDir = fs.lstatSync(path).isDirectory();
+  const shasumCommand = 'shasum -p -a 256';
+  const hashCommand = isDir
+    ? `find ${path} -type f -print0 | xargs -0 ${shasumCommand} | ${shasumCommand}`
+    : `${shasumCommand} ${path}`;
+  const result = child_process.spawnSync(hashCommand, [], {shell: true});
+  return result.stdout.toString().trim().split(' ')[0];
+}

--- a/src/filehash.ts
+++ b/src/filehash.ts
@@ -5,7 +5,7 @@ import * as child_process from 'child_process';
 import normalizePath from './normalizePath';
 
 /** Calculate a sha256 hash of a file or directory. */
-export default (path0: string) => {
+export default (path0: string, format: 'hex'|'base64' = 'hex') => {
   const path = normalizePath(path0);
   // this assumes local files/dirs TODO validate that
   if (!fs.existsSync(path)) {
@@ -16,6 +16,13 @@ export default (path0: string) => {
   const hashCommand = isDir
     ? `find ${path} -type f -print0 | xargs -0 ${shasumCommand} | ${shasumCommand}`
     : `${shasumCommand} ${path}`;
+
   const result = child_process.spawnSync(hashCommand, [], {shell: true});
-  return result.stdout.toString().trim().split(' ')[0];
+  const hexHash = result.stdout.toString().trim().split(' ')[0];
+  switch (format) {
+    case 'hex':
+      return hexHash;
+    case 'base64':
+      return Buffer.from(hexHash, 'hex').toString('base64');
+  }
 }

--- a/src/preprocess/index.ts
+++ b/src/preprocess/index.ts
@@ -27,6 +27,7 @@ import * as tv4 from 'tv4';
 import * as yaml from '../yaml';
 import {logger} from '../logger';
 import normalizePath from '../normalizePath';
+import filehash from '../filehash';
 import paginateAwsCall from '../paginateAwsCall';
 import {_getParamsByPath} from '../params';
 
@@ -262,18 +263,11 @@ export const importLoaders: {[key in ImportType]: ImportLoader} = {
   },
 
   filehash: async (location, baseLocation) => {
-    // this assumes local files/dirs TODO validate that
     const resolvedLocation = normalizePath(pathmod.dirname(baseLocation), location.split(':')[1]);
     if (!fs.existsSync(resolvedLocation)) {
       throw new Error(`Invalid location ${resolvedLocation} for filehash in ${baseLocation}`);
     }
-    const isDir = fs.lstatSync(resolvedLocation).isDirectory();
-    const shasumCommand = 'shasum -p -a 256';
-    const hashCommand = isDir
-      ? `find ${resolvedLocation} -type f -print0 | xargs -0 ${shasumCommand} | ${shasumCommand}`
-      : `${shasumCommand} ${resolvedLocation}`;
-    const result = child_process.spawnSync(hashCommand, [], {shell: true});
-    const data = result.stdout.toString().trim().split(' ')[0];
+    const data = filehash(resolvedLocation);
     return {resolvedLocation, data, doc: data};
   },
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -22,7 +22,7 @@ export function isStackArgsFile(location: string, doc: any): boolean {
   }
 }
 
-export type RenderArguments = GlobalArguments & {
+export type RenderArguments = GlobalArguments & Arguments & {
   template: string;
   outfile: string;
   overwrite: boolean;
@@ -41,8 +41,15 @@ export async function renderMain(argv: RenderArguments): Promise<number> {
     // TODO remove the cast to any below after tightening the args on _loadStackArgs
     outputDoc = await _loadStackArgs(rootDocLocation, argv as any);
   } else {
-    // injection of $region / $environment is handled by _loadStackArgs in the if branch above
-    input.$envValues = _.merge({}, input.$envValues, {iidy: {environment: argv.environment, region: getCurrentAWSRegion()}});
+    // injection of iidy env is handled by _loadStackArgs in the if branch above
+    input.$envValues = _.merge({}, input.$envValues, {
+      iidy: {
+        command: argv._.join(' '),
+        environment: argv.environment,
+        region: getCurrentAWSRegion()
+        // NOTE: missing profile which is present in stackArgs rendering
+      }
+    });
     outputDoc = await transform(input, rootDocLocation);
   }
   if (argv.query) {


### PR DESCRIPTION
**Merge after #113**

- Support handlebars templates in stack-args.yaml:CommandsBefore
- explicitly set the cwd for CommandsBefore to the directory containing stack-args.yaml. This was always the current directory previously.
- explicitly set the shell to /bin/bash if present
- add iidy.profile and iidy.command the stack-args preprocessor namespace.
- add base64 version of `filehash` imports
- add support for missing files in `filehash:` imports (e.g. `filehash:?dist/package.zip`)
- add `filehash` and `filehashBase64` as a handlebars helper available in CommandsBefore.
- exposes iidy.stackArgs, iidy.stackName, and any $imports / $defs from the stack-args to handlebars in CommandsBefore
- improves the logging of the commands & their output
- restrict execution of CommandsBefore to create-stack, update-stack, create-or-update, and create-changeset

Note, iidy render stack-args.yaml will currently strip out CommandsBefore but we could enhance this in the future to show the value of CommandsBefore after preprocessing the handlebars templates but without running the commands.
