### PR TITLE
tweak the `git:describe` import type to support non-annotated tags

### DIFF
--- a/src/preprocess/index.ts
+++ b/src/preprocess/index.ts
@@ -145,7 +145,7 @@ const gitValues = ["branch", "describe", "sha"];
 function gitValue(valueType: GitValue): string {
   const command = {
     branch: 'git rev-parse --abbrev-ref HEAD',
-    describe: 'git describe --dirty',
+    describe: 'git describe --dirty --tags',
     sha: 'git rev-parse HEAD'
   }[valueType];
 


### PR DESCRIPTION
Added --tags to `git describe` call, which allows 'use <of> any tag,
even unannotated'