### PR TITLE
allow --profile=no-profile and --assume-role-arn=no-role

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -471,13 +471,17 @@ export function buildArgs(commands = lazy, wrapMainHandler = wrapCommandHandler)
     .option('profile', {
       type: 'string', default: null,
       group: 'AWS Options:',
-      description: description('AWS profile. Can also be set via --environment & stack-args.yaml:Profile.')
+      description: description(
+        'AWS profile. Can also be set via --environment & stack-args.yaml:Profile. '
+        + 'Use --profile=no-profile to override values in stack-args.yaml and use AWS_* env vars.')
     })
     .option('assume-role-arn', {
       type: 'string', default: null,
       group: 'AWS Options:',
       description: description(
-        'AWS role. Can also be set via --environment & stack-args.yaml:AssumeRoleArn. This is mutually exclusive with --profile')
+        'AWS role. Can also be set via --environment & stack-args.yaml:AssumeRoleArn. '
+          + 'This is mutually exclusive with --profile. '
+          + 'Use --assume-role-arn=no-role to override values in stack-args.yaml and use AWS_* env vars.')
     })
 
     .option('debug', {

--- a/src/configureAWS.ts
+++ b/src/configureAWS.ts
@@ -22,7 +22,7 @@ import {AWSRegion} from './aws-regions';
 
 function getCredentialsProviderChain(profile?: string) {
   const hasDotAWS = (awsUserDir && fs.existsSync(awsUserDir));
-  if (profile) {
+  if (profile && ! _.includes(['no-profile', 'noprofile'], profile)) {
     if (profile.startsWith('arn:')) {
       throw new Error('profile was set to a role ARN. Use AssumeRoleArn instead');
     }
@@ -36,7 +36,7 @@ function getCredentialsProviderChain(profile?: string) {
 }
 
 async function resolveCredentials(profile?: string, assumeRoleArn?: string) {
-  if (assumeRoleArn) {
+  if (assumeRoleArn && ! _.includes(['no-role', 'norole'], assumeRoleArn)) {
     const masterCreds = await getCredentialsProviderChain(profile).resolvePromise();
     const tempCreds = new aws.TemporaryCredentials({RoleArn: assumeRoleArn, RoleSessionName: 'iidy'}, masterCreds);
     await tempCreds.getPromise();


### PR DESCRIPTION
Both options override any value set in stack-args.yaml and allow use of AWS_* env vars or instance profiles.

This allows us to support MFA authentication on roles that require it. The user would use a tool such as https://github.com/remind101/assume-role or call `aws sts assume-role` manually prior to invoking iidy.