### PR TITLE
disable the ora spinner in terms that don't support it

### DIFF
--- a/src/spinner.ts
+++ b/src/spinner.ts
@@ -1,3 +1,4 @@
+import * as process from 'process';
 import * as _ from 'lodash';
 import * as ora from 'ora';
 
@@ -14,11 +15,17 @@ export interface Spinner {
     text: string;
 }
 
-export default function (): Spinner {
+const INCOMPATIBLE_TERMS = ['eterm', 'eterm-color'];
+
+export function spinnerSupported() {
   const tty: any = process.stdout; // tslint:disable-line
+  return _.isNumber(tty.columns) && ! _.includes(INCOMPATIBLE_TERMS, process.env.TERM)
+}
+
+export default function (): Spinner {
   return ora({
     spinner: 'dots12',
     text: '',
-    enabled: _.isNumber(tty.columns)
+    enabled: spinnerSupported()
   });
 }


### PR DESCRIPTION
I noticed this while running it inside of emacs.