### PR TITLE
Add ability to render a directory of templates

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -390,6 +390,9 @@ export function buildArgs(commands = lazy, wrapMainHandler = wrapCommandHandler)
     (args) => args
       .demandCommand(0, 0)
       .usage('Usage: iidy render <input-template.yaml>')
+      .positional('template', {
+        description: 'template file to render, `-` for STDIN, can also be a directory of templates (will only render *.yml and *.yaml files in directory)'
+      })
       .option('outfile', {
         type: 'string', default: 'stdout',
         description: description('yaml input template to preprocess')

--- a/src/tests/test-render.ts
+++ b/src/tests/test-render.ts
@@ -21,7 +21,7 @@ describe('render', () => {
     const documents = [
       yaml.loadString('$defs:\n  foo: baz\nfoo: !$ foo', filename)
     ];
-    expect(await render(filename, documents, argv)).to.equal('foo: baz\n');
+    expect(await render(filename, documents, argv)).to.deep.equal(['foo: baz\n']);
   });
 
   it('can handle multiple documents', async () => {
@@ -29,7 +29,7 @@ describe('render', () => {
       yaml.loadString('$defs:\n  foo: bar\nfoo: !$ foo', filename),
       yaml.loadString('$defs:\n  foo: baz\nfoo: !$ foo', filename)
     ];
-    expect(await render(filename, documents, argv)).to.equal('---\nfoo: bar\n\n---\nfoo: baz\n');
+    expect(await render(filename, documents, argv)).to.deep.equal(['---', 'foo: bar\n', '---', 'foo: baz\n']);
   });
 
 });


### PR DESCRIPTION
`iidy render path/to/dir` will render all YAML files in that directory. All files in the directory will be rendered and outputted as a single, multi-document YAML file.

`iidy render file.yaml` behaves the same as before.