### PR TITLE
Ignore unused imports when running  template approval commands

### DIFF
--- a/src/approval/index.ts
+++ b/src/approval/index.ts
@@ -20,7 +20,8 @@ export type RequestArguments = GlobalArguments & {
 };
 
 export async function request(argv: RequestArguments): Promise<number> {
-  const stackArgs = await loadStackArgs(argv as any); // this calls configureAWS internally
+  const stackArgsKeys = ['ApprovedTemplateLocation', 'Template'];
+  const stackArgs = await loadStackArgs(argv as any, stackArgsKeys); // this calls configureAWS internally
 
   if (typeof stackArgs.ApprovedTemplateLocation === "string" && stackArgs.ApprovedTemplateLocation.length > 0) {
     const s3 = new S3();

--- a/src/preprocess/filter.ts
+++ b/src/preprocess/filter.ts
@@ -1,0 +1,21 @@
+import * as _ from 'lodash';
+import * as yaml from '../yaml';
+import {VariablesVisitor} from './visitor';
+
+export function filter(keys: string[], input: any, filename: string) {
+  const visitor = new VariablesVisitor();
+  const env = {
+    GlobalAccumulator: {},
+    $envValues: {},
+    Stack: [{location: filename, path: 'Root'}]
+  };
+  const output = _.pick(input, keys);
+  visitor.visitNode(output, 'Root', env);
+  if(input.$imports) {
+    output.$imports = _.pick(input.$imports, visitor.variables);
+  }
+  if(input.$defs) {
+    output.$defs = _.pick(input.$defs, visitor.variables);
+  }
+  return output;
+}

--- a/src/preprocess/visitor.ts
+++ b/src/preprocess/visitor.ts
@@ -691,12 +691,12 @@ export class VariablesVisitor extends Visitor {
     while (matches = regex.exec(node)) {
       this.variables.push(matches[1]);
     }
-    return super.visitHandlebarsString(node, path, env);
+    return node;
   }
 
   visit$include(node: yaml.$include, path: string, env: Env): AnyButUndefined {
     this.variables.push(node.data);
-    return super.visit$include(node, path, env);
+    return node.data;
   }
 
 }

--- a/src/preprocess/visitor.ts
+++ b/src/preprocess/visitor.ts
@@ -682,15 +682,62 @@ export class Visitor {
 
 }
 
+class HandlebarsVariablesVisitor extends handlebars.Visitor {
+  constructor(public variables: string[]) {
+    super();
+  };
+
+  BlockStatement(block: hbs.AST.BlockStatement): void {
+    if(_.isEmpty(block.params)) {
+      if('original' in block.path) {
+        this.variables.push(block.path.original);
+      }
+    } else {
+      for(let expression of block.params) {
+        this.Expression(expression);
+      }
+    }
+  }
+
+  PartialBlockStatement(partial: hbs.AST.PartialBlockStatement): void {
+    for(let expression of partial.params) {
+      this.Expression(expression);
+    }
+  }
+
+  MustacheStatement(mustache: hbs.AST.MustacheStatement): void {
+    if(_.isEmpty(mustache.params)) {
+      if('original' in mustache.path) {
+        this.variables.push(mustache.path.original);
+      }
+    } else {
+      for(let expression of mustache.params) {
+        this.Expression(expression);
+      }
+    }
+  }
+
+  // Expression is not part of handlebars.Visitor
+  Expression(expression: hbs.AST.Expression): void {
+    if('params' in expression) {
+      for(let ex of (expression as hbs.AST.SubExpression).params) {
+        this.Expression(ex);
+      }
+    } else {
+      if('original' in expression) {
+        this.variables.push((expression as hbs.AST.PathExpression).original);
+      }
+    }
+  }
+}
+
 export class VariablesVisitor extends Visitor {
   public variables: string[] = [];
 
   visitHandlebarsString(node: string, path: string, env: Env): string {
-    const regex = /{{ *(.*?) *}}/g;
-    let matches;
-    while (matches = regex.exec(node)) {
-      this.variables.push(matches[1]);
-    }
+    const ast = handlebars.parse(node);
+    const v = new HandlebarsVariablesVisitor(this.variables);
+    v.accept(ast);
     return node;
   }
 

--- a/src/tests/test-cfn.ts
+++ b/src/tests/test-cfn.ts
@@ -12,7 +12,7 @@ describe('cfn', () => {
         _: [''],
         '$0': ''
       };
-      const args = await loadStackArgs(argv, async () => {
+      const args = await loadStackArgs(argv, [], async () => {
         // Mock out with fake credentials. This is required for things like
         // addDefaultNotificationArn to fail silently
         aws.config.credentials = new aws.EnvironmentCredentials('TEST');

--- a/src/tests/test-filter.ts
+++ b/src/tests/test-filter.ts
@@ -1,0 +1,49 @@
+import * as _ from 'lodash';
+import {expect} from 'chai';
+
+import * as yaml from '../yaml';
+import {filter} from '../preprocess/filter';
+
+describe('filter', () => {
+  it('filters keys, $imports, and $defs', function() {
+    const input = {
+      $defs: {
+        a: 1,
+        b: 2
+      },
+      $imports: {
+        c: 3,
+        d: 4
+      },
+      one: new yaml.$include('a'),
+      two: new yaml.$include('b'),
+      three: new yaml.$include('c'),
+      four: new yaml.$include('d'),
+    };
+    const filtered = filter(['two', 'three'], input, 'test');
+    expect(_.keys(filtered)).to.deep.equal(['two', 'three', '$imports', '$defs']);
+    expect(_.keys(filtered.$defs)).to.deep.equal(['b'])
+    expect(_.keys(filtered.$imports)).to.deep.equal(['c'])
+
+  });
+
+  it('filters nested keys', function() {
+    const input = {
+      $defs: {
+        a: {
+          b: 1
+        },
+        c: {
+          d: 2,
+          e: 3
+        }
+      },
+      one: new yaml.$include('a.b'),
+      two: new yaml.$include('c.d'),
+    };
+      const filtered = filter(['two'], input, 'test');
+      expect(_.keys(filtered)).to.deep.equal(['two', '$defs']);
+      expect(_.keys(filtered.$defs)).to.deep.equal(['c'])
+      expect(_.keys(filtered.$defs.c)).to.deep.equal(['d'])
+  });
+});

--- a/src/tests/test-visitor.ts
+++ b/src/tests/test-visitor.ts
@@ -41,4 +41,20 @@ describe('VariablesVisitor', () => {
     }, 'test', mkTestEnv({foo: {bar: 'baz'} }));
     expect(visitor.variables).to.deep.equal(['foo.bar'])
   });
+
+  it('extracts variables from handlebars functions', function() {
+    const visitor = new VariablesVisitor();
+    visitor.visitNode({
+      foo: '{{ toLowerCase foo.bar }}'
+    }, 'test', mkTestEnv({foo: {bar: 'baz'} }));
+    expect(visitor.variables).to.deep.equal(['foo.bar'])
+  });
+
+  it('extracts variables from handlebars blocks', function() {
+    const visitor = new VariablesVisitor();
+    visitor.visitNode({
+      foo: '{{#if foo.bar }}{{/if}}'
+    }, 'test', mkTestEnv({foo: {bar: 'baz'} }));
+    expect(visitor.variables).to.deep.equal(['foo.bar'])
+  });
 });


### PR DESCRIPTION
This pull request builds on top of #150 to ignore unused imports during `template-approval` commands.