### PR TITLE
Show warning when unknown stack-args properties are added

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1304,6 +1304,16 @@
         "kuler": "1.0.1"
       }
     },
+    "didyoumean2": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/didyoumean2/-/didyoumean2-2.0.0.tgz",
+      "integrity": "sha512-OIwhEeiqg/H9Ptffpn/izxRY7xiM6thUjOYIUfo9QPa6jRkI0y3cHaY+uS42ky8zALXOQvuMfBalooRxf2bbAg==",
+      "requires": {
+        "leven": "2.1.0",
+        "lodash.deburr": "4.1.0",
+        "ramda": "0.25.0"
+      }
+    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -2649,6 +2659,11 @@
         "invert-kv": "1.0.0"
       }
     },
+    "leven": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -2691,6 +2706,11 @@
       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
       "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
       "dev": true
+    },
+    "lodash.deburr": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-4.1.0.tgz",
+      "integrity": "sha1-3bG7s+8HRYwBd7oH3hRCLLAz/5s="
     },
     "lodash.isarguments": {
       "version": "3.1.0",
@@ -3871,6 +3891,11 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
+    "ramda": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.25.0.tgz",
+      "integrity": "sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ=="
     },
     "randomatic": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "cli-color": "^1.4.0",
     "cfn-lint": "^1.9.2",
     "dateformat": "^3.0.3",
+    "didyoumean2": "^2.0.0",
     "escape-string-regexp": "^1.0.5",
     "handlebars": "^4.0.12",
     "inquirer": "^6.2.0",

--- a/src/cfn/index.ts
+++ b/src/cfn/index.ts
@@ -3,6 +3,7 @@ import * as pathmod from 'path';
 import * as process from 'process';
 import * as child_process from 'child_process';
 import * as url from 'url';
+import didYouMean from 'didyoumean2';
 
 import * as _ from 'lodash';
 import * as aws from 'aws-sdk'
@@ -943,7 +944,12 @@ export async function loadStackArgs(argv: GenericCLIArguments,
 function showArgsfileWarnings(argsdata: object, filename: string) {
   const invalidProperties = _.difference(_.keys(argsdata), stackArgsProperties);
   _.forEach(invalidProperties, (name: string) => {
-    logger.warn(`Invalid property '${name}' in ${filename}`);
+    let suggestion = '';
+    const suggestedProperty = didYouMean(name, stackArgsProperties);
+    if (suggestedProperty) {
+      suggestion = `. Did you mean '${suggestedProperty}'?`
+    }
+    logger.warn(`Invalid property '${name}' in ${filename}${suggestion}`);
   });
 }
 

--- a/src/cfn/index.ts
+++ b/src/cfn/index.ts
@@ -86,7 +86,7 @@ export type StackArgs = {
   CommandsBefore?: string[]
 }
 
-const stackArgsProperties = [
+const stackArgsProperties: Array<keyof StackArgs> = [
   'ApprovedTemplateLocation',
   'AssumeRoleARN',
   'Capabilities',

--- a/src/cfn/index.ts
+++ b/src/cfn/index.ts
@@ -110,6 +110,8 @@ const stackArgsProperties: Array<keyof StackArgs> = [
   'UsePreviousTemplate',
 ];
 
+const stackArgsMetaProperties = ['$imports', '$defs'];
+
 async function getReliableStartTime(): Promise<Date> {
   const startTime = await getReliableTime();
   startTime.setTime(startTime.getTime() - 500); // to be safe
@@ -942,7 +944,9 @@ export async function loadStackArgs(argv: GenericCLIArguments,
 }
 
 function showArgsfileWarnings(argsdata: object, filename: string) {
-  const invalidProperties = _.difference(_.keys(argsdata), stackArgsProperties);
+  const invalidProperties = _.difference(_.keys(argsdata),
+                                         stackArgsProperties,
+                                         stackArgsMetaProperties);
   _.forEach(invalidProperties, (name: string) => {
     let suggestion = '';
     const suggestedProperty = didYouMean(name, stackArgsProperties);

--- a/src/preprocess/visitor.ts
+++ b/src/preprocess/visitor.ts
@@ -46,7 +46,13 @@ export const mkSubEnv = (env: Env, $envValues: $EnvValues, frame: MaybeStackFram
 const _liftKVPairs = (objects: {key: string, value: any}[]) =>
   _.fromPairs(_.map(objects, ({key, value}) => [key, value]))
 
-const extendedCfnDocKeys = ['$imports', '$defs', '$params', '$location', '$envValues'];
+export const extendedCfnDocKeys = [
+  '$imports',
+  '$defs',
+  '$params',
+  '$location',
+  '$envValues'
+];
 
 function mapCustomResourceToGlobalSections(
   resourceDoc: ExtendedCfnDoc,


### PR DESCRIPTION
Example output:

```
warn Invalid property 'ServiceRoleArn' in a.yaml. Did you mean 'ServiceRoleARN'?
warn Invalid property 'foo' in a.yaml
```

Fixes #131 