### PR TITLE
Write error-level logs to stderr

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -41,6 +41,7 @@ if (debug()) {
 
 const consoleLogger = new winston.transports.Console({
   level: LOG_LEVEL,
+  stderrLevels: ['error'],
   format: combine((useColor ? winston.format.colorize() : winston.format.simple()),
     consoleFormat)
 });


### PR DESCRIPTION
Error log messages are written to stdout, which will get swallowed if piped into another command:

```
$ cat test.yaml
foo: !$ a

$ bin/iidy render test.yaml --format json | jq
parse error: Invalid numeric literal at line 1, column 6
```
Error is from `jq` ☝️ 

With this change:
```
$ bin/iidy render test.yaml --format json | jq
error Could not find "a" at a in Root.foo
```
Error is from `iidy` ☝️ (printed to stderr)