### PR TITLE
Fixes a performance regression between v1.6.5..v1.6.6-rc2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -352,15 +352,6 @@
       "integrity": "sha512-NtJmi+XbYocrLb5Au4Q64srX4FlCPDvrSF/OnK3H0QJwrw40tIUoQPDoUHnZ5wpAB2KThtVyeS+kOEQyZabORg==",
       "dev": true
     },
-    "@types/winston": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/@types/winston/-/winston-2.4.4.tgz",
-      "integrity": "sha512-BVGCztsypW8EYwJ+Hq+QNYiT/MUyCif0ouBH+flrY66O5W+KIXAMML6E/0fJpm7VjIzgangahl5S03bJJQGrZw==",
-      "dev": true,
-      "requires": {
-        "winston": "*"
-      }
-    },
     "@types/wrap-ansi": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
@@ -520,11 +511,18 @@
       "dev": true
     },
     "async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
       "requires": {
-        "lodash": "^4.17.10"
+        "lodash": "^4.17.14"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
       }
     },
     "asynckit": {
@@ -1071,14 +1069,14 @@
       "integrity": "sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y="
     },
     "colors": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
-      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
     },
     "colorspace": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.1.tgz",
-      "integrity": "sha512-pI3btWyiuz7Ken0BWh9Elzsmv2bM9AhA7psXib4anUXy/orfZ/E0MbQwhSOG/9L8hLlalqrU0UhOuqxW1YjmVw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
+      "integrity": "sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==",
       "requires": {
         "color": "3.0.x",
         "text-hex": "1.0.x"
@@ -1795,9 +1793,9 @@
       "dev": true
     },
     "fast-safe-stringify": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz",
-      "integrity": "sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg=="
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
     },
     "fecha": {
       "version": "2.3.3",
@@ -3238,9 +3236,9 @@
       },
       "dependencies": {
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -6324,9 +6322,8 @@
       }
     },
     "winston": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.2.1.tgz",
-      "integrity": "sha512-zU6vgnS9dAWCEKg/QYigd6cgMVVNwyTzKs81XZtTFuRwJOcDdBg7AU0mXVyNbs7O5RH2zdv+BdNZUlx7mXPuOw==",
+      "version": "github:winstonjs/winston#1a7554486dd71e5656b4fd3cd9168fc3620df9a8",
+      "from": "github:winstonjs/winston#1a7554486dd71e5656b4fd3cd9168fc3620df9a8",
       "requires": {
         "async": "^2.6.1",
         "diagnostics": "^1.1.1",
@@ -6340,9 +6337,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
-          "integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "tmp": "^0.1.0",
     "ts-md5": "^1.2.4",
     "tv4": "^1.3.0",
-    "winston": "^3.2.1",
+    "winston": "winstonjs/winston#1a7554486dd71e5656b4fd3cd9168fc3620df9a8",
     "wrap-ansi": "^5.1.0",
     "yargs": "^13.2.2"
   },
@@ -69,7 +69,6 @@
     "@types/sprintf-js": "^1.1.2",
     "@types/tmp": "^0.1.0",
     "@types/tv4": "^1.2.29",
-    "@types/winston": "^2.4.4",
     "@types/wrap-ansi": "^3.0.0",
     "@types/yargs": "^12.0.1",
     "chai": "^4.2.0",

--- a/src/preprocess/visitor.ts
+++ b/src/preprocess/visitor.ts
@@ -314,7 +314,7 @@ export class Visitor {
       const subPath = appendPath(path, idx.toString());
       const item = this.visitNode(item0, subPath, env); // visit pre expansion
       const subEnv = mkSubEnv(
-        env, _.merge({[varName]: item, [varName + 'Idx']: idx}, env.$envValues), {path: subPath});
+        env, {...env.$envValues, [varName]: item, [varName + 'Idx']: idx}, {path: subPath});
       if (node.data.filter && !this.visitNode(node.data.filter, path, subEnv)) {
         return SENTINEL;
       } else {
@@ -493,7 +493,10 @@ export class Visitor {
 
   visitNode(node: any, path: string, env: Env): any {
     const currNode = path.split('.').pop();
-    logger.debug(`entering ${path}:`, {node, nodeType: typeof node, env});
+    // Avoid serializing large `env` data when debug is not enabled
+    if(logger.isDebugEnabled()) {
+      logger.debug(`entering ${path}:`, {node, nodeType: typeof node, env});
+    }
     const result = (() => {
       if (currNode === 'Resources' && path.indexOf('Overrides') === -1) {
         return this.visitResourceNode(node, path, env);
@@ -514,7 +517,9 @@ export class Visitor {
         return node;
       }
     })();
-    logger.debug(`exiting ${path}:`, {result, node, env});;
+    if(logger.isDebugEnabled()) {
+      logger.debug(`exiting ${path}:`, {result, node, env});;
+    }
     return result;
   };
 


### PR DESCRIPTION
There appear to be two sources:

- winston JSON serializes log metadata (the third parameter) even if it will not
  be logged due to an insufficient log level
- `_.merge` called when creating a "sub" env for `$map` can copy large amounts of
  data if there are large `$imports`