### PR TITLE
add DELETE_SKIPPED as a colorized status

### DIFF
--- a/src/cfn/formatting.ts
+++ b/src/cfn/formatting.ts
@@ -4,7 +4,7 @@ import * as dateformat from 'dateformat';
 import * as _ from 'lodash';
 import {sprintf} from 'sprintf-js';
 import {FAILURE, SUCCESS} from '../statusCodes';
-import {COMPLETE, FAILED, IN_PROGRESS} from './statusTypes';
+import {COMPLETE, FAILED, IN_PROGRESS, SKIPPED} from './statusTypes';
 
 export const COLUMN2_START = 25;
 export const DEFAULT_STATUS_PADDING = 35;
@@ -38,9 +38,12 @@ export function colorizeResourceStatus(status: string, padding = DEFAULT_STATUS_
   const fail = cli.redBright;
   const progress = cli.yellow;
   const complete = cli.green;
+  const skipped = cli.blue;
 
   if (_.includes(FAILED, status)) {
     return fail(padded);
+  } else if (_.includes(SKIPPED, status)) {
+    return skipped(padded);
   } else if (_.includes(COMPLETE, status)) {
     return complete(padded);
   } else if (_.includes(IN_PROGRESS, status)) {
@@ -48,7 +51,6 @@ export function colorizeResourceStatus(status: string, padding = DEFAULT_STATUS_
   } else {
     return padded;
   }
-
 }
 
 export const prettyFormatSmallMap = (map: {[key: string]: string}): string => {

--- a/src/cfn/statusTypes.ts
+++ b/src/cfn/statusTypes.ts
@@ -47,5 +47,10 @@ export const FAILED = [
 ] as const;
 export type FAILED = typeof FAILED[number];
 
-export type TERMINAL = COMPLETE | FAILED | 'REVIEW_IN_PROGRESS';
-export const TERMINAL: TERMINAL[] = (COMPLETE as any).concat(FAILED).concat(['REVIEW_IN_PROGRESS']);
+export const SKIPPED = [
+  'DELETE_SKIPPED'
+] as const;
+export type SKIPPED = typeof SKIPPED[number];
+
+export type TERMINAL = COMPLETE | FAILED | SKIPPED | 'REVIEW_IN_PROGRESS';
+export const TERMINAL: TERMINAL[] = (COMPLETE as any).concat(FAILED).concat(SKIPPED).concat(['REVIEW_IN_PROGRESS']);


### PR DESCRIPTION
Recently made a change to one of my stacks that involved a resource having a DeletionPolicy of "Retain". CFN sets the status of the resource to DELETE_SKIPPED, which I noticed didn't have a color set.

I used blue just to make it stand out a bit more and make it evident that a skip event happened.