### PR TITLE
Deprecate non-camelCase helpers

### DIFF
--- a/docs/yaml-preprocessing.md
+++ b/docs/yaml-preprocessing.md
@@ -170,47 +170,53 @@ handlebars-helpers](https://github.com/helpers/handlebars-helpers#string) (such
 as `titleize`, `trim`, `reverse`, etc) are included for basic string
 manipulation in addition to the following helpers.
 
-#### `tojson`
+#### `toJson`
 
 ```yaml
 $defs:
   a:
     b: 9
 
-out: '{{tojson a}}'
+out: '{{toJson a}}'
 ```
 
 ```yaml
 out: '{"b":9}'
 ```
 
-#### `tojsonPretty`
+`tojson` is an alias of `toJson` and is deprecated.
+
+#### `toJsonPretty`
 
 ```yaml
 $defs:
   a:
     b:
       c: 9
-out: '{{tojsonPretty a}}'
+out: '{{toJsonPretty a}}'
 ```
 
 ```yaml
 out: '{\n \"b\": {\n  \"c\": 9\n }\n}'
 ```
 
-#### `toyaml`
+`tojsonPretty` is an alias of `toJsonPretty` and is deprecated.
+
+#### `toYaml`
 
 ```yaml
 $defs:
   a:
     b: 9
 
-out: '{{toyaml a}}'
+out: '{{toYaml a}}'
 ```
 
 ```yaml
 out: 'b: 9\n'
 ```
+
+`toyaml` is an alias of `toYaml` and is deprecated.
 
 #### `toLowerCase`
 

--- a/src/preprocess/index.ts
+++ b/src/preprocess/index.ts
@@ -32,9 +32,14 @@ import paginateAwsCall from '../paginateAwsCall';
 import {_getParamsByPath} from '../params';
 import {Visitor} from './visitor';
 
+// `tojson`, `tojsonPretty`, and `toyaml` are deprecated in favour of the camelCase version
 handlebars.registerHelper('tojson', (context: any) => JSON.stringify(context));
 handlebars.registerHelper('tojsonPretty', (context: any) => JSON.stringify(context, null, ' '));
 handlebars.registerHelper('toyaml', (context: any) => yaml.dump(context));
+
+handlebars.registerHelper('toJson', (context: any) => JSON.stringify(context));
+handlebars.registerHelper('toJsonPretty', (context: any) => JSON.stringify(context, null, ' '));
+handlebars.registerHelper('toYaml', (context: any) => yaml.dump(context));
 handlebars.registerHelper('base64', (context: any) => Buffer.from(context).toString('base64'));
 handlebars.registerHelper('toLowerCase', (str: string) => str.toLowerCase());
 handlebars.registerHelper('toUpperCase', (str: string) => str.toUpperCase());

--- a/src/tests/test-yaml-preprocessing.ts
+++ b/src/tests/test-yaml-preprocessing.ts
@@ -325,18 +325,18 @@ aref: !$ nested.aref`, mockLoader)).to.deep.equal({aref: 'mock'});
 
     describe('helper functions', () => {
 
-      it('tojson', async () => {
-        expect(await transform({$defs: {a: {b: 9}}, out: '{{tojson a}}'}))
+      it('toJson', async () => {
+        expect(await transform({$defs: {a: {b: 9}}, out: '{{toJson a}}'}))
           .to.deep.equal({out: '{"b":9}'});
       });
 
-      it('tojsonPretty', async () => {
-        expect(await transform({$defs: {a: {b: {c: 9}}}, out: '{{tojsonPretty a}}'}))
+      it('toJsonPretty', async () => {
+        expect(await transform({$defs: {a: {b: {c: 9}}}, out: '{{toJsonPretty a}}'}))
           .to.deep.equal({out: '{\n \"b\": {\n  \"c\": 9\n }\n}'});
       });
 
-      it('toyaml', async () => {
-        expect(await transform({$defs: {a: {b: 9}}, out: '{{toyaml a}}'}))
+      it('toYaml', async () => {
+        expect(await transform({$defs: {a: {b: 9}}, out: '{{toYaml a}}'}))
           .to.deep.equal({out: 'b: 9\n'});
       });
 


### PR DESCRIPTION
Deprecate helpers that do not follow the camelCase casing convention.