### PR TITLE
Avoid calling fs.statSync when input is from stdin

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -37,7 +37,7 @@ export async function renderMain(argv0: GenericCLIArguments): Promise<number> {
   const file = isStdin ? 0 : templatePath;
   let output: string[] = [];
 
-  if (fs.statSync(templatePath).isDirectory()) {
+  if (!isStdin && fs.statSync(templatePath).isDirectory()) {
     for (const filename of fs.readdirSync(templatePath)) {
       if (filename.match(/\.(yml|yaml)$/)) {
         const filepath = pathmod.resolve(templatePath, filename);


### PR DESCRIPTION
fs.statSync will throw an error when the "file" does not exist (in the case of "-" for stdin).

Fixes #260