### PR TITLE
update aws-sdk-js version (with our creds cache patch)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "auto-changelog": "2.3.0",
-        "aws-sdk": "github:unbounce/aws-sdk-js#e3528b1490257ec60ea2c2bc9eb0129d42f17263",
+        "aws-sdk": "github:unbounce/aws-sdk-js#32191b99dfa10120fa48701593db3315d17e7e45",
         "bluebird": "3.7.2",
         "cli-color": "^2.0.0",
         "dateformat": "4.5.1",
@@ -1862,9 +1862,12 @@
       }
     },
     "node_modules/aws-sdk": {
-      "resolved": "git+https://git@github.com/unbounce/aws-sdk-js.git#e3528b1490257ec60ea2c2bc9eb0129d42f17263",
+      "version": "2.996.0",
+      "resolved": "git+https://git@github.com/unbounce/aws-sdk-js.git#32191b99dfa10120fa48701593db3315d17e7e45",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "buffer": "4.9.1",
+        "buffer": "4.9.2",
         "events": "1.1.1",
         "ieee754": "1.1.13",
         "jmespath": "0.15.0",
@@ -1873,6 +1876,9 @@
         "url": "0.10.3",
         "uuid": "3.3.2",
         "xml2js": "0.4.19"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/aws-sign2": {
@@ -2100,9 +2106,9 @@
       }
     },
     "node_modules/buffer": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
       "dependencies": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4",
@@ -11630,10 +11636,10 @@
       }
     },
     "aws-sdk": {
-      "version": "git+https://git@github.com/unbounce/aws-sdk-js.git#e3528b1490257ec60ea2c2bc9eb0129d42f17263",
-      "from": "aws-sdk@github:unbounce/aws-sdk-js#e3528b1490257ec60ea2c2bc9eb0129d42f17263",
+      "version": "git+https://git@github.com/unbounce/aws-sdk-js.git#32191b99dfa10120fa48701593db3315d17e7e45",
+      "from": "aws-sdk@github:unbounce/aws-sdk-js#32191b99dfa10120fa48701593db3315d17e7e45",
       "requires": {
-        "buffer": "4.9.1",
+        "buffer": "4.9.2",
         "events": "1.1.1",
         "ieee754": "1.1.13",
         "jmespath": "0.15.0",
@@ -11821,9 +11827,9 @@
       }
     },
     "buffer": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
       "requires": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "auto-changelog": "2.3.0",
-    "aws-sdk": "github:unbounce/aws-sdk-js#e3528b1490257ec60ea2c2bc9eb0129d42f17263",
+    "aws-sdk": "github:unbounce/aws-sdk-js#32191b99dfa10120fa48701593db3315d17e7e45",
     "bluebird": "3.7.2",
     "cli-color": "^2.0.0",
     "dateformat": "4.5.1",

--- a/src/cfn/approval/index.ts
+++ b/src/cfn/approval/index.ts
@@ -1,9 +1,10 @@
-import {S3, AWSError} from 'aws-sdk';
+import {S3} from 'aws-sdk';
 import * as cli from 'cli-color';
 import * as _ from 'lodash';
 import * as path from 'path';
 import * as url from 'url';
 import {GlobalArguments} from '../../cli/utils';
+import isAWSError from '../../is-aws-error';
 import configureAWS from '../../configureAWS';
 import confirmationPrompt from '../../confirmationPrompt';
 import {diff} from '../../diff';
@@ -35,7 +36,7 @@ export async function request(argv: RequestArguments): Promise<number> {
       await s3.headObject(s3Args).promise();
       logSuccess(`👍 Your template has already been approved`);
     } catch (e) {
-      if (e instanceof AWSError && e.code === "NotFound") {
+      if (isAWSError(e) && e.code === "NotFound") {
         s3Args.Key = `${s3Args.Key}.pending`
         const cfnTemplate = await loadCFNTemplate(stackArgs.Template, argv.argsfile, argv.environment, {omitMetadata: true}, S3_TEMPLATE_MAX_BYTES);
         if (argv.lintTemplate && cfnTemplate.TemplateBody) {
@@ -91,7 +92,7 @@ export async function review(argv: ReviewArguments): Promise<number> {
 
     logSuccess(`👍 The template has already been approved`);
   } catch (e) {
-    if (e instanceof AWSError && e.code === 'NotFound') {
+    if (isAWSError(e) && e.code === 'NotFound') {
 
       const pendingTemplate = await s3.getObject({
         Bucket: s3Bucket,

--- a/src/is-aws-error.ts
+++ b/src/is-aws-error.ts
@@ -1,0 +1,3 @@
+import type {AWSError} from 'aws-sdk/lib/error';
+
+export default (err: unknown): err is AWSError => (err as AWSError).code !== undefined;

--- a/src/params/index.ts
+++ b/src/params/index.ts
@@ -5,6 +5,7 @@ import * as jsyaml from 'js-yaml';
 
 import {GlobalArguments} from '../cli/utils';
 
+import isAWSError from '../is-aws-error';
 import getCurrentAWSRegion from '../getCurrentAWSRegion';
 import configureAWS from '../configureAWS';
 import def from '../default';
@@ -134,7 +135,7 @@ async function maybeFetchParam(ssm: aws.SSM, req: aws.SSM.GetParameterRequest): 
     const res = await ssm.getParameter(req).promise();
     return res && res.Parameter;
   } catch (e) {
-    if (e instanceof aws.AWSError && e.code && e.code === 'ParameterNotFound') {
+    if (isAWSError(e) && e.code && e.code === 'ParameterNotFound') {
       return undefined;
     } else {
       throw e;


### PR DESCRIPTION
This is based on https://github.com/unbounce/aws-sdk-js/tree/update-credentials-cache-patch which is patch that applies MFA credentials caching on top of the latest aws/aws-sdk-js v2 (similar to what the aws cli does).

The original upstream PR which this is updated from is @jpb's https://github.com/aws/aws-sdk-js/issues/2611. 