### PR TITLE
Allow successful completion with cleanup in progress

### DIFF
--- a/src/cfn/index.ts
+++ b/src/cfn/index.ts
@@ -40,7 +40,7 @@ class CreateStack extends AbstractCloudFormationStackCommand {
 
 class UpdateStack extends AbstractCloudFormationStackCommand {
   cfnOperation: CfnOperation = 'UPDATE_STACK';
-  expectedFinalStackStatus = ['UPDATE_COMPLETE'];
+  expectedFinalStackStatus = ['UPDATE_COMPLETE', 'UPDATE_COMPLETE_CLEANUP_IN_PROGRESS'];
 
   async _run() {
     return this._runUpdate();
@@ -130,7 +130,7 @@ export class CreateChangeSet extends AbstractCloudFormationStackCommand {
 
 class ExecuteChangeSet extends AbstractCloudFormationStackCommand {
   cfnOperation: CfnOperation = 'EXECUTE_CHANGESET'
-  expectedFinalStackStatus = ['UPDATE_COMPLETE', 'CREATE_COMPLETE']
+  expectedFinalStackStatus = ['UPDATE_COMPLETE', 'UPDATE_COMPLETE_CLEANUP_IN_PROGRESS', 'CREATE_COMPLETE']
 
   async _run() {
     await this.cfn.executeChangeSet(


### PR DESCRIPTION
This PR allows successful completion of commands with status `UPDATE_COMPLETE_CLEANUP_IN_PROGRESS`, which is coming up in eu-central-1 and causing iidy to fail builds.