### PR TITLE
Waits for terminal stack status when summarizing

### DIFF
--- a/src/cfn/getStackDescription.ts
+++ b/src/cfn/getStackDescription.ts
@@ -1,9 +1,18 @@
+import { TERMINAL } from './statusTypes';
+
 import * as _ from 'lodash';
 import * as aws from 'aws-sdk'
 
-export async function getStackDescription(StackName: string): Promise<aws.CloudFormation.Stack> {
+export async function getStackDescription(StackName: string, expectTerminalStatus: boolean = false): Promise<aws.CloudFormation.Stack> {
   const cfn = new aws.CloudFormation();
-  const stacks = await cfn.describeStacks({StackName}).promise();
+  const stacks = await (async () => {
+    if (expectTerminalStatus) {
+      while (!_.includes(TERMINAL, (await cfn.describeStacks({StackName}).promise()).Stacks![0].StackStatus)) {
+        await new Promise(resolve => setTimeout(resolve, 1000));
+      }
+    }
+    return await cfn.describeStacks({StackName}).promise();
+  })();
   if (_.isUndefined(stacks.Stacks) || stacks.Stacks.length < 1) {
     throw new Error(`${StackName} not found. Has it been deleted? Check the AWS Console.`);
   } else {

--- a/src/cfn/index.ts
+++ b/src/cfn/index.ts
@@ -40,7 +40,7 @@ class CreateStack extends AbstractCloudFormationStackCommand {
 
 class UpdateStack extends AbstractCloudFormationStackCommand {
   cfnOperation: CfnOperation = 'UPDATE_STACK';
-  expectedFinalStackStatus = ['UPDATE_COMPLETE', 'UPDATE_COMPLETE_CLEANUP_IN_PROGRESS'];
+  expectedFinalStackStatus = ['UPDATE_COMPLETE'];
 
   async _run() {
     return this._runUpdate();
@@ -130,7 +130,7 @@ export class CreateChangeSet extends AbstractCloudFormationStackCommand {
 
 class ExecuteChangeSet extends AbstractCloudFormationStackCommand {
   cfnOperation: CfnOperation = 'EXECUTE_CHANGESET'
-  expectedFinalStackStatus = ['UPDATE_COMPLETE', 'UPDATE_COMPLETE_CLEANUP_IN_PROGRESS', 'CREATE_COMPLETE']
+  expectedFinalStackStatus = ['UPDATE_COMPLETE', 'CREATE_COMPLETE']
 
   async _run() {
     await this.cfn.executeChangeSet(

--- a/src/cfn/summarizeStackContents.ts
+++ b/src/cfn/summarizeStackContents.ts
@@ -26,7 +26,7 @@ export async function summarizeStackContents(
   const resourcesPromise = cfn.describeStackResources({StackName: StackId}).promise();
   const exportsPromise = getAllStackExportsWithImports(StackId);
   const changeSetsPromise = cfn.listChangeSets({StackName: StackId}).promise();
-  const stack = await (stackPromise || getStackDescription(StackId));
+  const stack = await (stackPromise || getStackDescription(StackId, true));
   const resources = def([], (await resourcesPromise).StackResources);
   // TODO paginate resource lookup ^
   if (resources.length > 0) {


### PR DESCRIPTION
For some reason, we are getting non-terminal statuses when summarizing. It's possible this is a timing issue, so we'll naïvely attempt to get the stack description again until we receive a response with a terminal status.

By the time we make this call, we already know that we'll be in a terminal status because the watcher will only stop once we've seen a terminal status. This is why the logging will always have something like:

```
09:46:01 GMT-07:00   Thu Jun 20 2024 16:45:57 UPDATE_COMPLETE                              AWS::IAM::Role                           
09:46:01 GMT-07:00                                                                            CloudwatchLogRole (17s)
09:46:01 GMT-07:00  - 39 seconds elapsed total. 21 since last event.
09:46:06 GMT-07:00   Thu Jun 20 2024 16:46:00 UPDATE_COMPLETE_CLEANUP_IN_PROGRESS          AWS::CloudFormation::Stack               
09:46:06 GMT-07:00                                                                            eks-etc-titan-production
09:46:06 GMT-07:00   Thu Jun 20 2024 16:46:02 UPDATE_COMPLETE                              AWS::CloudFormation::Stack               
09:46:06 GMT-07:00                                                                            eks-etc-titan-production (36s)
```

where the last line will be `UPDATE_COMPLETE`, but iidy will summarize with

```
09:46:08 GMT-07:00  Current Stack Status:     UPDATE_COMPLETE_CLEANUP_IN_PROGRESS 
```

which is clearly not the status from the last line.