### PR TITLE
Update deprecated github cache action

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,7 +8,7 @@ jobs:
       SKIP_IIDY_AWS_TEST: yes
     steps:
       - uses: actions/checkout@master
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}


### PR DESCRIPTION
Migrating from v1 to v4 as per https://github.com/actions/cache/discussions/1510